### PR TITLE
Comptime arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CORrosive RIEmann Solver (corrosive because it's written in Rust...)
 
 Deps:
 
-- Add rayon for parallel iterators
+- Add rayon for parallel iterators ++ rayon feature for ndarray
 - Add crossbeam for scoped threads
 
 Things I can probably parallelise:
@@ -27,6 +27,8 @@ Things to read:
 
 ### Small things
 
+- [ ] Fix Mesh unit tests
+- [ ] add approx features for ndarray?
 - [ ] Add unit tests for Units and Variables
 - [ ] more linting?
 - [ ] can I macro metadata_dump?

--- a/examples/template.rs
+++ b/examples/template.rs
@@ -11,17 +11,13 @@ use corries::units::UnitsMode;
 use corries::{config, get_n_equations};
 
 fn main() -> Result<()> {
-    const MESH_COMP_AREA_SIZE: usize = 10;
-    const MESH_N_GHOST_CELLS: usize = 2;
-
+    const SIZE: usize = 14;
     const N_EQUATIONS: usize = get_n_equations(PhysicsMode::Euler1DIsot);
 
-    run_sim(config::CorriesConfig {
+    run_sim::<SIZE, N_EQUATIONS>(config::CorriesConfig {
         name: "accretiondisk".to_string(),
         meshconf: MeshConfig {
             mode: MeshMode::Cartesian,
-            n_comp: 10,
-            n_gc: 2,
             xi_in: 0.1,
             xi_out: 10.0,
             ratio_disk: 1.0,

--- a/examples/template.rs
+++ b/examples/template.rs
@@ -3,7 +3,7 @@
 // License: MIT
 
 use color_eyre::Result;
-use corries::config;
+use corries::{config, get_n_equations};
 use corries::config::meshconfig::{MeshConfig, MeshMode};
 use corries::config::outputconfig::{DataName, FormatterMode, OutputConfig, StreamMode, ToStringConversionMode};
 use corries::config::physicsconfig::{PhysicsConfig, PhysicsMode};
@@ -11,6 +11,11 @@ use corries::run_sim;
 use corries::units::UnitsMode;
 
 fn main() -> Result<()> {
+    const MESH_COMP_AREA_SIZE: usize = 10;
+    const MESH_N_GHOST_CELLS: usize = 2;
+
+    const N_EQUATIONS: usize = get_n_equations(PhysicsMode::Euler1DIsot);
+
     run_sim(config::CorriesConfig {
         name: "accretiondisk".to_string(),
         meshconf: MeshConfig {

--- a/examples/template.rs
+++ b/examples/template.rs
@@ -3,12 +3,12 @@
 // License: MIT
 
 use color_eyre::Result;
-use corries::{config, get_n_equations};
 use corries::config::meshconfig::{MeshConfig, MeshMode};
 use corries::config::outputconfig::{DataName, FormatterMode, OutputConfig, StreamMode, ToStringConversionMode};
 use corries::config::physicsconfig::{PhysicsConfig, PhysicsMode};
 use corries::run_sim;
 use corries::units::UnitsMode;
+use corries::{config, get_n_equations};
 
 fn main() -> Result<()> {
     const MESH_COMP_AREA_SIZE: usize = 10;

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,14 +47,14 @@ impl Validation for CorriesConfig {
 impl CorriesConfig {
     /// Writes metadata, mostly just the contents of this struct and its nested structs, into a
     /// `String`.
-    pub fn metadata_dump(&self) -> String {
+    pub fn metadata_dump<const MESH_COMP_SIZE: usize>(&self) -> String {
         let mut s = "".to_string();
         s += "### Corries Configuration\n";
         s += &format!("# name: {}\n", self.name);
         s += "# meshconf:\n";
         s += &format!("#     mode: {:?}\n", self.meshconf.mode);
-        s += &format!("#     n_comp: {}\n", self.meshconf.n_comp);
-        s += &format!("#     n_gc: {}\n", self.meshconf.n_gc);
+        s += &format!("#     n_comp: {}\n", MESH_COMP_SIZE);
+        // s += &format!("#     n_gc: {}\n", NGC);
         s += &format!("#     xi_in: {}\n", self.meshconf.xi_in);
         s += &format!("#     xi_out: {}\n", self.meshconf.xi_out);
         s += &format!("#     ratio_disk: {}\n", self.meshconf.ratio_disk);

--- a/src/config/meshconfig.rs
+++ b/src/config/meshconfig.rs
@@ -19,12 +19,6 @@ pub struct MeshConfig {
     /// The type of Mesh that should constructed
     pub mode: MeshMode,
 
-    /// The number of cells in the computational area
-    pub n_comp: usize,
-
-    /// The number of ghost cells per edge
-    pub n_gc: usize,
-
     /// xi coordinate at the inner/western boundary of the computational area
     pub xi_in: f64,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,16 +5,16 @@
 use color_eyre::{eyre::Context, Result};
 use config::{physicsconfig::PhysicsMode, CorriesConfig};
 use mesh::Mesh;
-// use physics::init_physics;
+use physics::init_physics;
 use writer::Writer;
 
-use crate::{config::outputconfig::StreamMode, errorhandling::Validation, /*rhs::Rhs*/};
+use crate::{config::outputconfig::StreamMode, errorhandling::Validation /*rhs::Rhs*/};
 
 pub mod config;
 #[macro_use]
 mod errorhandling;
 mod mesh;
-// mod physics;
+mod physics;
 // mod rhs;
 pub mod units;
 mod writer;
@@ -27,8 +27,7 @@ mod writer;
 pub fn run_sim<const S: usize, const EQ: usize>(config: CorriesConfig) -> Result<()> {
     config.validate().context("Validating config")?;
     let mesh: Mesh<S> = Mesh::new(&config.meshconf).context("Constructing Mesh")?;
-    println!("{}", mesh.xi_cent);
-    // let _u = init_physics(&config.physicsconf, &mesh).context("Constructing Physics")?;
+    let _u = init_physics::<S, EQ>(&config.physicsconf);
     // let _rhs = Rhs::new();
     //
     // // TEMP:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,17 +5,17 @@
 use color_eyre::{eyre::Context, Result};
 use config::{physicsconfig::PhysicsMode, CorriesConfig};
 use mesh::Mesh;
-use physics::init_physics;
+// use physics::init_physics;
 use writer::Writer;
 
-use crate::{config::outputconfig::StreamMode, errorhandling::Validation, rhs::Rhs};
+use crate::{config::outputconfig::StreamMode, errorhandling::Validation, /*rhs::Rhs*/};
 
 pub mod config;
 #[macro_use]
 mod errorhandling;
 mod mesh;
-mod physics;
-mod rhs;
+// mod physics;
+// mod rhs;
 pub mod units;
 mod writer;
 
@@ -24,22 +24,23 @@ mod writer;
 /// # Arguments
 ///
 /// * `config` - The `CorriesConfig` the simulation is based on
-pub fn run_sim(config: CorriesConfig) -> Result<()> {
+pub fn run_sim<const S: usize, const EQ: usize>(config: CorriesConfig) -> Result<()> {
     config.validate().context("Validating config")?;
-    let mesh = Mesh::new(&config.meshconf).context("Constructing Mesh")?;
-    let _u = init_physics(&config.physicsconf, &mesh).context("Constructing Physics")?;
-    let _rhs = Rhs::new();
-
-    // TEMP:
+    let mesh: Mesh<S> = Mesh::new(&config.meshconf).context("Constructing Mesh")?;
+    println!("{}", mesh.xi_cent);
+    // let _u = init_physics(&config.physicsconf, &mesh).context("Constructing Physics")?;
+    // let _rhs = Rhs::new();
+    //
+    // // TEMP:
     let output_count_max = 2;
     let mut writer = Writer::new(&config, &mesh, output_count_max)?;
-
-    // first output
+    //
+    // // first output
     if writer.outputs.iter().any(|o| o.stream_mode == StreamMode::Stdout) {
         print_banner();
     }
     writer.update_data_matrices(&mesh)?;
-    writer.write_metadata(&config)?;
+    writer.write_metadata::<S>(&config)?;
     writer.write_output()?;
     return Ok(());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,14 +8,14 @@ use mesh::Mesh;
 use physics::init_physics;
 use writer::Writer;
 
-use crate::{config::outputconfig::StreamMode, errorhandling::Validation /*rhs::Rhs*/};
+use crate::{config::outputconfig::StreamMode, errorhandling::Validation, rhs::Rhs};
 
 pub mod config;
 #[macro_use]
 mod errorhandling;
 mod mesh;
 mod physics;
-// mod rhs;
+mod rhs;
 pub mod units;
 mod writer;
 
@@ -28,8 +28,8 @@ pub fn run_sim<const S: usize, const EQ: usize>(config: CorriesConfig) -> Result
     config.validate().context("Validating config")?;
     let mesh: Mesh<S> = Mesh::new(&config.meshconf).context("Constructing Mesh")?;
     let _u = init_physics::<S, EQ>(&config.physicsconf);
-    // let _rhs = Rhs::new();
-    //
+    let _rhs = Rhs::new();
+
     // // TEMP:
     let output_count_max = 2;
     let mut writer = Writer::new(&config, &mesh, output_count_max)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 // License: MIT
 
 use color_eyre::{eyre::Context, Result};
-use config::CorriesConfig;
+use config::{physicsconfig::PhysicsMode, CorriesConfig};
 use mesh::Mesh;
 use physics::init_physics;
 use writer::Writer;
@@ -42,6 +42,12 @@ pub fn run_sim(config: CorriesConfig) -> Result<()> {
     writer.write_metadata(&config)?;
     writer.write_output()?;
     return Ok(());
+}
+
+pub const fn get_n_equations(physics_mode: PhysicsMode) -> usize {
+    return match physics_mode {
+        PhysicsMode::Euler1DIsot => 2,
+    };
 }
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -21,7 +21,7 @@ use ndarray::Array1;
 /// cylindrical coordinates you would name them xi = r (the radius), Phi = phi (the polar angle),
 /// eta = z.
 #[derive(Debug)]
-pub struct Mesh<const SIZE: usize> {
+pub struct Mesh<const S: usize> {
     /// The kind of mesh this is, i.e. cartesian, log-cylindrical, etc.
     pub mode: MeshMode,
 
@@ -196,22 +196,22 @@ pub struct Mesh<const SIZE: usize> {
     pub minus_cepe: Array1<f64>,
 }
 
-impl<const SIZE: usize> Mesh<SIZE> {
+impl<const S: usize> Mesh<S> {
     /// Builds a new `color_eyre::Result<Mesh>` object.
     ///
     /// # Arguments
     ///
     /// * `meshconf` - `MeshConfig` containing configuration to build `Mesh` objects
-    pub fn new(meshconf: &MeshConfig) -> Result<Mesh<SIZE>> {
+    pub fn new(meshconf: &MeshConfig) -> Result<Mesh<S>> {
         let mode = meshconf.mode;
         let is_logarithmic = match mode {
             MeshMode::Cartesian => false,
         };
         let is_linear = !is_logarithmic;
 
-        let n_all = SIZE;
+        let n_all = S;
         let n_gc = 2;
-        let n_comp = SIZE - 2 * n_gc;
+        let n_comp = S - 2 * n_gc;
 
         let imin = 0;
         let imax = imin + n_all - 1;
@@ -235,7 +235,7 @@ impl<const SIZE: usize> Mesh<SIZE> {
         };
 
         let xi_west = {
-            let mut v = Array1::zeros(SIZE);
+            let mut v = Array1::zeros(S);
             let mut f = |x: f64| {
                 for i in imin..=imax {
                     v[i] = x + dxi * (i as i64 - ixi_in as i64) as f64;
@@ -388,7 +388,7 @@ impl<const SIZE: usize> Mesh<SIZE> {
     }
 }
 
-impl<const SIZE: usize> Validation for Mesh<SIZE> {
+impl<const S: usize> Validation for Mesh<S> {
     fn validate(&self) -> Result<()> {
         // checks on doubles
         check_finite_multiple_doubles![self.dxi, self.deta, self.dphi];
@@ -440,7 +440,7 @@ impl<const SIZE: usize> Validation for Mesh<SIZE> {
     }
 }
 
-impl<const SIZE: usize> CorriesWrite for Mesh<SIZE> {
+impl<const S: usize> CorriesWrite for Mesh<S> {
     fn collect_data(&self, name: &DataName, value: &mut DataValue, mesh_offset: usize) -> Result<()> {
         match (name.association(), name) {
             (StructAssociation::Mesh, DataName::XiCent) => self.write_vector(&self.xi_cent, value, mesh_offset),
@@ -464,13 +464,13 @@ impl<const SIZE: usize> CorriesWrite for Mesh<SIZE> {
 mod tests {
     use super::*;
     use proptest::prelude::*;
-    const MESH_COMP_SIZE: usize = 1004;
+    const S: usize = 1004;
     // TODO: more test submodules with different sized meshes?
     prop_compose! {
         fn arb_mesh(mode: MeshMode)
                     (xi_in in 0.1f64..100_000.0,
                     xi_out in 0.1f64..100_000.0,
-                    ratio_disk in 0.1f64..=1.0) -> Result<Mesh<MESH_COMP_SIZE>> {
+                    ratio_disk in 0.1f64..=1.0) -> Result<Mesh<S>> {
             return Mesh::new(&MeshConfig { mode, xi_in, xi_out, ratio_disk });
         }
     }

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -8,7 +8,7 @@ use crate::errorhandling::Validation;
 use crate::writer::{CorriesWrite, DataValue};
 use color_eyre::eyre::{ensure, Context};
 use color_eyre::Result;
-use ndarray::{ArrayD, IxDyn};
+use ndarray::Array1;
 
 /// The Mesh the simulation runs on.
 ///
@@ -21,7 +21,7 @@ use ndarray::{ArrayD, IxDyn};
 /// cylindrical coordinates you would name them xi = r (the radius), Phi = phi (the polar angle),
 /// eta = z.
 #[derive(Debug)]
-pub struct Mesh {
+pub struct Mesh<const SIZE: usize> {
     /// The kind of mesh this is, i.e. cartesian, log-cylindrical, etc.
     pub mode: MeshMode,
 
@@ -79,139 +79,139 @@ pub struct Mesh {
     pub dphi: f64,
 
     /// xi coordinates at the center of each cell
-    pub xi_cent: ArrayD<f64>,
+    pub xi_cent: Array1<f64>,
 
     /// xi coordinates at the west border of each cell
-    pub xi_west: ArrayD<f64>,
+    pub xi_west: Array1<f64>,
 
     /// xi coordinates at the east border of each cell
-    pub xi_east: ArrayD<f64>,
+    pub xi_east: Array1<f64>,
 
     /// Inverse of xi_cent
-    pub xi_cent_inv: ArrayD<f64>,
+    pub xi_cent_inv: Array1<f64>,
 
     /// Inverse of xi_west
-    pub xi_west_inv: ArrayD<f64>,
+    pub xi_west_inv: Array1<f64>,
 
     /// Inverse of xi_east
-    pub xi_east_inv: ArrayD<f64>,
+    pub xi_east_inv: Array1<f64>,
 
     /// Geometric scale along xi at the centre of each cell
-    pub h_xi_cent: ArrayD<f64>,
+    pub h_xi_cent: Array1<f64>,
 
     /// Geometric scale along xi at the west border of each cell
-    pub h_xi_west: ArrayD<f64>,
+    pub h_xi_west: Array1<f64>,
 
     /// Geometric scale along xi at the east border of each cell
-    pub h_xi_east: ArrayD<f64>,
+    pub h_xi_east: Array1<f64>,
 
     /// Geometric scale along eta at the centre of each cell
-    pub h_eta_cent: ArrayD<f64>,
+    pub h_eta_cent: Array1<f64>,
 
     /// Geometric scale along eta at the west border of each cell
-    pub h_eta_west: ArrayD<f64>,
+    pub h_eta_west: Array1<f64>,
 
     /// Geometric scale along eta at the east border of each cell
-    pub h_eta_east: ArrayD<f64>,
+    pub h_eta_east: Array1<f64>,
 
     /// Geometric scale along Phi at the centre of each cell
-    pub h_phi_cent: ArrayD<f64>,
+    pub h_phi_cent: Array1<f64>,
 
     /// Geometric scale along Phi at the west border of each cell
-    pub h_phi_west: ArrayD<f64>,
+    pub h_phi_west: Array1<f64>,
 
     /// Geometric scale along Phi at the east border of each cell
-    pub h_phi_east: ArrayD<f64>,
+    pub h_phi_east: Array1<f64>,
 
     /// Square root of the scalar metric
-    pub sqrt_g: ArrayD<f64>,
+    pub sqrt_g: Array1<f64>,
 
     /// Line element along xi
-    pub line_xi: ArrayD<f64>,
+    pub line_xi: Array1<f64>,
 
     /// Inverse of line_xi
-    pub line_xi_inv: ArrayD<f64>,
+    pub line_xi_inv: Array1<f64>,
 
     /// Shorthand: area_west / (deta / dphi)
-    pub d_area_xi_deta_dphi_west: ArrayD<f64>,
+    pub d_area_xi_deta_dphi_west: Array1<f64>,
 
     /// Shorthand: area_east / (deta / dphi)
-    pub d_area_xi_deta_dphi_east: ArrayD<f64>,
+    pub d_area_xi_deta_dphi_east: Array1<f64>,
 
     /// Surface area of each cell normal to xi x Phi
-    pub area_cell: ArrayD<f64>,
+    pub area_cell: Array1<f64>,
 
     /// Surface area of each cell's west border normal to Phi x eta
-    pub area_west: ArrayD<f64>,
+    pub area_west: Array1<f64>,
 
     /// Surface area of each cell's east border normal to Phi x eta
-    pub area_east: ArrayD<f64>,
+    pub area_east: Array1<f64>,
 
     /// Volume of each cell
-    pub volume: ArrayD<f64>,
+    pub volume: Array1<f64>,
 
     /// Shorthand: deta * dPhi / dVolume
-    pub deta_dphi_d_volume: ArrayD<f64>,
+    pub deta_dphi_d_volume: Array1<f64>,
 
     /// Distance between west and east border of each cell
-    pub cell_width: ArrayD<f64>,
+    pub cell_width: Array1<f64>,
 
     /// Inverse of cell_width
-    pub cell_width_inv: ArrayD<f64>,
+    pub cell_width_inv: Array1<f64>,
 
     /// Commutator coefficient for eta and xi
-    pub cexe: ArrayD<f64>,
+    pub cexe: Array1<f64>,
 
     /// Commutator coefficient for Phi and xi
-    pub cpxp: ArrayD<f64>,
+    pub cpxp: Array1<f64>,
 
     /// Commutator coefficient for xi and eta
-    pub cxex: ArrayD<f64>,
+    pub cxex: Array1<f64>,
 
     /// Commutator coefficient for Phi and eta
-    pub cpep: ArrayD<f64>,
+    pub cpep: Array1<f64>,
 
     /// Commutator coefficient for xi and Phi
-    pub cxpx: ArrayD<f64>,
+    pub cxpx: Array1<f64>,
 
     /// Commutator coefficient for eta and Phi
-    pub cepe: ArrayD<f64>,
+    pub cepe: Array1<f64>,
 
     /// Shorthand: -1.0 * cexe
-    pub minus_cexe: ArrayD<f64>,
+    pub minus_cexe: Array1<f64>,
 
     /// Shorthand: -1.0 * cpxp
-    pub minus_cpxp: ArrayD<f64>,
+    pub minus_cpxp: Array1<f64>,
 
     /// Shorthand: -1.0 * cxex
-    pub minus_cxex: ArrayD<f64>,
+    pub minus_cxex: Array1<f64>,
 
     /// Shorthand: -1.0 * cpep
-    pub minus_cpep: ArrayD<f64>,
+    pub minus_cpep: Array1<f64>,
 
     /// Shorthand: -1.0 * cxpx
-    pub minus_cxpx: ArrayD<f64>,
+    pub minus_cxpx: Array1<f64>,
 
     /// Shorthand: -1.0 * cepe
-    pub minus_cepe: ArrayD<f64>,
+    pub minus_cepe: Array1<f64>,
 }
 
-impl Mesh {
+impl<const SIZE: usize> Mesh<SIZE> {
     /// Builds a new `color_eyre::Result<Mesh>` object.
     ///
     /// # Arguments
     ///
     /// * `meshconf` - `MeshConfig` containing configuration to build `Mesh` objects
-    pub fn new(meshconf: &MeshConfig) -> Result<Mesh> {
+    pub fn new(meshconf: &MeshConfig) -> Result<Mesh<SIZE>> {
         let mode = meshconf.mode;
         let is_logarithmic = match mode {
             MeshMode::Cartesian => false,
         };
         let is_linear = !is_logarithmic;
 
-        let n_comp = meshconf.n_comp;
-        let n_gc = meshconf.n_gc;
-        let n_all = n_comp + 2 * n_gc;
+        let n_all = SIZE;
+        let n_gc = 2;
+        let n_comp = SIZE - 2 * n_gc;
 
         let imin = 0;
         let imax = imin + n_all - 1;
@@ -235,16 +235,16 @@ impl Mesh {
         };
 
         let xi_west = {
-            let mut v: Vec<f64> = Vec::with_capacity(n_all);
+            let mut v = Array1::zeros(SIZE);
             let mut f = |x: f64| {
                 for i in imin..=imax {
-                    v.push(x + dxi * (i as i64 - ixi_in as i64) as f64);
+                    v[i] = x + dxi * (i as i64 - ixi_in as i64) as f64;
                 }
             };
             match mode {
                 MeshMode::Cartesian => f(xi_in),
             };
-            ndarray::ArrayD::from_shape_vec(IxDyn(&[v.len()]), v).context("Constructing xi_west")?
+            v
         };
         let xi_cent = match mode {
             MeshMode::Cartesian => xi_west.mapv(|xi| xi + 0.5 * dxi),
@@ -388,7 +388,7 @@ impl Mesh {
     }
 }
 
-impl Validation for Mesh {
+impl<const SIZE: usize> Validation for Mesh<SIZE> {
     fn validate(&self) -> Result<()> {
         // checks on doubles
         check_finite_multiple_doubles![self.dxi, self.deta, self.dphi];
@@ -440,7 +440,7 @@ impl Validation for Mesh {
     }
 }
 
-impl CorriesWrite for Mesh {
+impl<const SIZE: usize> CorriesWrite for Mesh<SIZE> {
     fn collect_data(&self, name: &DataName, value: &mut DataValue, mesh_offset: usize) -> Result<()> {
         match (name.association(), name) {
             (StructAssociation::Mesh, DataName::XiCent) => self.write_vector(&self.xi_cent, value, mesh_offset),
@@ -464,14 +464,14 @@ impl CorriesWrite for Mesh {
 mod tests {
     use super::*;
     use proptest::prelude::*;
+    const MESH_COMP_SIZE: usize = 1004;
+    // TODO: more test submodules with different sized meshes?
     prop_compose! {
         fn arb_mesh(mode: MeshMode)
-                    (n_gc in 1usize..=2,
-                    n_comp in 3usize..10_000,
-                    xi_in in 0.1f64..100_000.0,
+                    (xi_in in 0.1f64..100_000.0,
                     xi_out in 0.1f64..100_000.0,
-                    ratio_disk in 0.1f64..=1.0) -> Result<Mesh> {
-            return Mesh::new(&MeshConfig { mode, n_comp, n_gc, xi_in, xi_out, ratio_disk });
+                    ratio_disk in 0.1f64..=1.0) -> Result<Mesh<MESH_COMP_SIZE>> {
+            return Mesh::new(&MeshConfig { mode, xi_in, xi_out, ratio_disk });
         }
     }
 

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -2,25 +2,20 @@
 // Author: Tommy Breslein (github.com/tbreslein)
 // License: MIT
 
-use color_eyre::Result;
-
-use crate::{
-    config::physicsconfig::{PhysicsConfig, PhysicsMode},
-    mesh::Mesh,
-};
+use crate::config::physicsconfig::{PhysicsConfig, PhysicsMode};
 
 use self::{systems::euler1disot::Euler1DIsot, variables::Variables};
 
 mod systems;
 pub mod variables;
 
-pub trait Physics {
-    fn update_cons(&self, vars: &mut Variables);
-    fn update_prim(&self, vars: &mut Variables);
+pub trait Physics<const S: usize, const EQ: usize> {
+    fn update_cons(&self, vars: &mut Variables<S, EQ>);
+    fn update_prim(&self, vars: &mut Variables<S, EQ>);
 }
 
-pub fn init_physics(physicsconf: &PhysicsConfig, mesh: &Mesh) -> Result<Box<dyn Physics>> {
+pub fn init_physics<const S: usize, const EQ: usize>(physicsconf: &PhysicsConfig) -> Box<dyn Physics<S, EQ>> {
     return match physicsconf.mode {
-        PhysicsMode::Euler1DIsot => Euler1DIsot::new(physicsconf, mesh),
+        PhysicsMode::Euler1DIsot => Box::new(Euler1DIsot::new(physicsconf)),
     };
 }

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -4,7 +4,10 @@
 
 use color_eyre::Result;
 
-use crate::{config::physicsconfig::{PhysicsConfig, PhysicsMode}, mesh::Mesh};
+use crate::{
+    config::physicsconfig::{PhysicsConfig, PhysicsMode},
+    mesh::Mesh,
+};
 
 use self::{systems::euler1disot::Euler1DIsot, variables::Variables};
 

--- a/src/physics/systems/euler1disot.rs
+++ b/src/physics/systems/euler1disot.rs
@@ -5,7 +5,12 @@
 use color_eyre::Result;
 use ndarray::Axis;
 
-use crate::{config::physicsconfig::PhysicsConfig, mesh::Mesh, units::Units, physics::{variables::Variables, Physics}};
+use crate::{
+    config::physicsconfig::PhysicsConfig,
+    mesh::Mesh,
+    physics::{variables::Variables, Physics},
+    units::Units,
+};
 
 pub struct Euler1DIsot {
     pub cent: Variables,
@@ -16,18 +21,22 @@ impl Euler1DIsot {
     pub fn new(physicsconf: &PhysicsConfig, mesh: &Mesh) -> Result<Box<dyn Physics>> {
         let cent = Variables::new(physicsconf, mesh);
         let units = Units::new(physicsconf.units_mode);
-        return Ok(Box::new(Euler1DIsot {cent, units}));
+        return Ok(Box::new(Euler1DIsot { cent, units }));
     }
 }
 
 impl Physics for Euler1DIsot {
     fn update_cons(&self, vars: &mut Variables) {
         vars.c.index_axis_mut(Axis(0), 0).assign(&vars.p.index_axis(Axis(0), 0));
-        vars.c.index_axis_mut(Axis(0), 1).assign(&(&vars.p.index_axis(Axis(0), 1) * &vars.p.index_axis(Axis(0), 0)));
+        vars.c
+            .index_axis_mut(Axis(0), 1)
+            .assign(&(&vars.p.index_axis(Axis(0), 1) * &vars.p.index_axis(Axis(0), 0)));
     }
 
     fn update_prim(&self, vars: &mut Variables) {
         vars.p.index_axis_mut(Axis(0), 0).assign(&vars.c.index_axis(Axis(0), 0));
-        vars.p.index_axis_mut(Axis(0), 1).assign(&(&vars.c.index_axis(Axis(0), 1) / &vars.c.index_axis(Axis(0), 0)));
+        vars.p
+            .index_axis_mut(Axis(0), 1)
+            .assign(&(&vars.c.index_axis(Axis(0), 1) / &vars.c.index_axis(Axis(0), 0)));
     }
 }

--- a/src/physics/systems/euler1disot.rs
+++ b/src/physics/systems/euler1disot.rs
@@ -2,38 +2,36 @@
 // Author: Tommy Breslein (github.com/tbreslein)
 // License: MIT
 
-use color_eyre::Result;
 use ndarray::Axis;
 
 use crate::{
     config::physicsconfig::PhysicsConfig,
-    mesh::Mesh,
     physics::{variables::Variables, Physics},
     units::Units,
 };
 
-pub struct Euler1DIsot {
-    pub cent: Variables,
+pub struct Euler1DIsot<const S: usize, const EQ: usize> {
+    pub cent: Variables<S, EQ>,
     pub units: Units,
 }
 
-impl Euler1DIsot {
-    pub fn new(physicsconf: &PhysicsConfig, mesh: &Mesh) -> Result<Box<dyn Physics>> {
-        let cent = Variables::new(physicsconf, mesh);
+impl<const S: usize, const EQ: usize> Euler1DIsot<S, EQ> {
+    pub fn new(physicsconf: &PhysicsConfig) -> Self {
+        let cent = Variables::new(physicsconf);
         let units = Units::new(physicsconf.units_mode);
-        return Ok(Box::new(Euler1DIsot { cent, units }));
+        return Euler1DIsot { cent, units };
     }
 }
 
-impl Physics for Euler1DIsot {
-    fn update_cons(&self, vars: &mut Variables) {
+impl<const S: usize, const EQ: usize> Physics<S, EQ> for Euler1DIsot<S, EQ> {
+    fn update_cons(&self, vars: &mut Variables<S, EQ>) {
         vars.c.index_axis_mut(Axis(0), 0).assign(&vars.p.index_axis(Axis(0), 0));
         vars.c
             .index_axis_mut(Axis(0), 1)
             .assign(&(&vars.p.index_axis(Axis(0), 1) * &vars.p.index_axis(Axis(0), 0)));
     }
 
-    fn update_prim(&self, vars: &mut Variables) {
+    fn update_prim(&self, vars: &mut Variables<S, EQ>) {
         vars.p.index_axis_mut(Axis(0), 0).assign(&vars.c.index_axis(Axis(0), 0));
         vars.p
             .index_axis_mut(Axis(0), 1)

--- a/src/physics/variables.rs
+++ b/src/physics/variables.rs
@@ -2,14 +2,11 @@
 // Author: Tommy Breslein (github.com/tbreslein)
 // License: MIT
 
-use ndarray::{ArrayD, IxDyn};
+use ndarray::{Array1, Array2};
 
-use crate::{
-    config::physicsconfig::{PhysicsConfig, PhysicsMode},
-    mesh::Mesh,
-};
+use crate::config::physicsconfig::{PhysicsConfig, PhysicsMode};
 
-pub struct Variables {
+pub struct Variables<const S: usize, const EQ: usize> {
     /// The type of physics equations we are solving
     pub mode: PhysicsMode,
 
@@ -17,13 +14,13 @@ pub struct Variables {
     pub n_equations: usize,
 
     /// Primitive variables
-    pub p: ArrayD<f64>,
+    pub p: Array2<f64>,
 
     /// Conservative variables
-    pub c: ArrayD<f64>,
+    pub c: Array2<f64>,
 
     /// Speed of sound
-    pub c_sound: ArrayD<f64>,
+    pub c_sound: Array1<f64>,
 
     /// Possible equation index for density
     pub jdensity: Option<usize>,
@@ -44,22 +41,22 @@ pub struct Variables {
     pub is_isothermal: bool,
 }
 
-impl Variables {
+impl<const S: usize, const EQ: usize> Variables<S, EQ> {
     /// Builds a new `Variables` object.
     ///
     /// # Arguments
     ///
     /// * `physicsconf` - `PhysicsConfig` containing configuration to build `Physics` and `Variables` objects
-    /// * `mesh` - provides information about the mesh in this simulation
-    pub fn new(physicsconf: &PhysicsConfig, mesh: &Mesh) -> Variables {
+    pub fn new(physicsconf: &PhysicsConfig) -> Variables<S, EQ> {
         let mode = physicsconf.mode;
         let n_equations = match mode {
             PhysicsMode::Euler1DIsot => 2,
         };
 
-        let p = ArrayD::from_elem(IxDyn(&[mesh.n_all, n_equations]), 0.0);
-        let c = ArrayD::from_elem(IxDyn(&[mesh.n_all, n_equations]), 0.0);
-        let c_sound = ArrayD::from_elem(IxDyn(&[mesh.n_all]), 0.0);
+        // let mut v = Array1::zeros(S);
+        let p = Array2::zeros((S, EQ));
+        let c = Array2::zeros((S, EQ));
+        let c_sound = Array1::zeros(S);
 
         let jdensity = match mode {
             PhysicsMode::Euler1DIsot => Some(0),

--- a/src/rhs.rs
+++ b/src/rhs.rs
@@ -2,8 +2,6 @@
 // Author: Tommy Breslein (github.com/tbreslein)
 // License: MIT
 
-use color_eyre::Result;
-
 use self::numflux::init_numflux;
 
 mod numflux;
@@ -13,9 +11,9 @@ pub struct Rhs {
 }
 
 impl Rhs {
-    pub fn new() -> Result<Rhs> {
-        return Ok(Rhs {
+    pub fn new() -> Self {
+        return Rhs {
             _numflux: init_numflux(),
-        });
+        };
     }
 }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -37,7 +37,7 @@ impl Writer {
     /// * `config` - Configuration for a corries simulation
     /// * `mesh` - The mesh for this simulation
     /// * `output_count_max` - How many output steps this simulation should be going through
-    pub fn new<const SIZE: usize>(config: &CorriesConfig, mesh: &Mesh<SIZE>, output_count_max: usize) -> Result<Self> {
+    pub fn new<const S: usize>(config: &CorriesConfig, mesh: &Mesh<S>, output_count_max: usize) -> Result<Self> {
         let mut outputs = vec![];
         for outputconf in config.writerconf.iter() {
             let output = Output::new(outputconf, mesh, output_count_max)?;
@@ -51,7 +51,7 @@ impl Writer {
     /// # Arguments
     ///
     /// * `mesh` - Provides mesh data
-    pub fn update_data_matrices<const SIZE: usize>(&mut self, mesh: &Mesh<SIZE>) -> Result<()> {
+    pub fn update_data_matrices<const S: usize>(&mut self, mesh: &Mesh<S>) -> Result<()> {
         // TODO: can I safely thread this loop?
         for output in self.outputs.iter_mut() {
             output.update_data_matrix(mesh)?;


### PR DESCRIPTION
Adds generics for arrays dimensions.

Main reason for this change is being able to switch to static arrays, instead of using dynamic ones, which is a sizeable performance boost.
Most functions and methods will now need you to pass to generic parameters, which are going to be called `const S: usize` for the size the mesh, and `const EQ: usize` for the number of equations we are solving for.