### PR TITLE
benchmarking and performance sweep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,10 @@ harness = false
 
 [dependencies]
 color-eyre = { version = "0.6", default-features = false }
-ndarray = { version = "0.15", features = ["blas", "approx-0_5"] }
+ndarray = { version = "0.15", features = ["blas", "approx-0_5", "rayon"] }
 blas-src = { version = "0.8", features = ["openblas"] }
 openblas-src = { version = "0.10", features = ["cblas", "system"] }
+rayon = "1.5.3"
 
 [dev-dependencies]
 proptest = { version = "1" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ mod boundaryconditions;
 pub mod config;
 #[macro_use]
 mod errorhandling;
-mod mesh;
+pub mod mesh;
 pub mod physics;
 mod rhs;
 mod timeintegration;
@@ -80,7 +80,9 @@ pub fn run_loop<const S: usize, const EQ: usize>(
     writer: &mut Writer,
 ) -> Result<()> {
     loop {
-        if timeintegration.time.t >= timeintegration.time.t_next_output {
+        if timeintegration.time.t_next_output <= timeintegration.time.t
+            && timeintegration.time.t <= timeintegration.time.t_end
+        {
             timeintegration.time.t_next_output += timeintegration.time.dt_output;
 
             writer
@@ -91,7 +93,7 @@ pub fn run_loop<const S: usize, const EQ: usize>(
                 .write_output()
                 .context("Calling wirter.write_output in run_sim")?;
         }
-        if timeintegration.time.t >= timeintegration.time.t_end {
+        if timeintegration.time.t + timeintegration.time.dt_min * 0.01 >= timeintegration.time.t_end {
             break;
         }
 

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -421,7 +421,7 @@ mod tests {
                 // converting to cons and back to prim should be idempotent
                 u.update_cons();
                 u.update_prim();
-                assert_relative_eq!(u.prim, u0.prim, max_relative = 1.0e-10);
+                assert_relative_eq!(u.prim, u0.prim, max_relative = 1.0e-8);
             }
         }
     }

--- a/src/physics/systems/euler1disot.rs
+++ b/src/physics/systems/euler1disot.rs
@@ -1,4 +1,4 @@
-use ndarray::{azip, Array2};
+use ndarray::{Array2, Zip};
 
 use super::super::Physics;
 
@@ -6,31 +6,39 @@ impl<const S: usize, const EQ: usize> Physics<S, EQ> {
     /// Updates conservative density and xi momentum according to the isothermal Euler equations
     #[inline(always)]
     pub fn update_cons_euler1d_isot(&mut self) {
-        self.cons.row_mut(self.jdensity).assign(&self.prim.row(self.jdensity));
+        Zip::from(self.cons.row_mut(self.jdensity))
+            .and(self.prim.row(self.jdensity))
+            .for_each(|cons_dens, &prim_dens| *cons_dens = prim_dens);
+
         self.update_cons_linear_momentum_euler(self.jximomentum);
     }
 
     /// Updates primitive density and xi velocity according to the isothermal Euler equations
     #[inline(always)]
     pub fn update_prim_euler1d_isot(&mut self) {
-        self.prim.row_mut(self.jdensity).assign(&self.cons.row(self.jdensity));
+        Zip::from(self.prim.row_mut(self.jdensity))
+            .and(self.cons.row(self.jdensity))
+            .for_each(|prim_dens, &cons_dens| *prim_dens = cons_dens);
+
         self.update_prim_linear_velocity_euler(self.jxivelocity);
     }
 
     /// Calculates and updates the linear momentum in [self.cons] at row `j`.
     #[inline(always)]
     pub fn update_cons_linear_momentum_euler(&mut self, j: usize) {
-        self.cons
-            .row_mut(j)
-            .assign(&(&self.prim.row(j) * &self.prim.row(self.jdensity)));
+        Zip::from(self.cons.row_mut(j))
+            .and(self.prim.row(j))
+            .and(self.prim.row(self.jdensity))
+            .for_each(|momentum, &velocity, &density| *momentum = velocity * density);
     }
 
     /// Calculates and updates the linear velocity in [self.prim] at row `j`.
     #[inline(always)]
     pub fn update_prim_linear_velocity_euler(&mut self, j: usize) {
-        self.prim
-            .row_mut(j)
-            .assign(&(&self.cons.row(j) / &self.cons.row(self.jdensity)));
+        Zip::from(self.prim.row_mut(j))
+            .and(self.cons.row(j))
+            .and(self.cons.row(self.jdensity))
+            .for_each(|velocity, &momentum, &density| *velocity = momentum / density);
     }
 
     /// Updates the speed of sound vector; no-op for isothermal physics
@@ -49,24 +57,20 @@ impl<const S: usize, const EQ: usize> Physics<S, EQ> {
     /// Calculates the density flux for isothermal 1D Euler
     #[inline(always)]
     pub fn calc_density_flux_euler1d_isot(&self, flux: &mut Array2<f64>) {
-        azip!(
-            (
-                dens_flux in flux.row_mut(self.jdensity),
-                &ximom in self.cons.row(self.jximomentum)
-            )
-            *dens_flux = ximom);
+        Zip::from(flux.row_mut(self.jdensity))
+            .and(self.cons.row(self.jximomentum))
+            .for_each(|dens_flux, &xi_momentum| *dens_flux = xi_momentum);
     }
 
     /// Calculates the xi momentum flux for isothermal 1D Euler
     #[inline(always)]
     pub fn calc_xi_momentum_flux_euler1d_isot(&self, flux: &mut Array2<f64>) {
-        azip!(
-            (
-                ximom_flux in flux.row_mut(self.jximomentum),
-                &dens in self.cons.row(self.jdensity),
-                &xivel in self.prim.row(self.jxivelocity),
-                &cs in &self.c_sound
-            )
-            *ximom_flux = dens * (xivel * xivel + cs * cs));
+        Zip::from(flux.row_mut(self.jximomentum))
+            .and(self.cons.row(self.jdensity))
+            .and(self.prim.row(self.jxivelocity))
+            .and(&self.c_sound)
+            .for_each(|xi_momentum_flux, &density, &xi_velocity, &cs| {
+                *xi_momentum_flux = density * (xi_velocity * xi_velocity + cs * cs)
+            });
     }
 }

--- a/src/physics/systems/euler2disot.rs
+++ b/src/physics/systems/euler2disot.rs
@@ -1,4 +1,4 @@
-use ndarray::{azip, Array2};
+use ndarray::{Array2, Zip};
 
 use super::super::Physics;
 
@@ -27,12 +27,9 @@ impl<const S: usize, const EQ: usize> Physics<S, EQ> {
     /// Calculates the eta momentum flux for isothermal 2D Euler
     #[inline(always)]
     pub fn calc_eta_momentum_flux_euler2d_isot(&self, flux: &mut Array2<f64>) {
-        azip!(
-            (
-                etamom_flux in flux.row_mut(self.jetamomentum),
-                &xivel in self.prim.row(self.jxivelocity),
-                &etamom in self.cons.row(self.jetamomentum)
-            )
-            *etamom_flux = xivel * etamom);
+        Zip::from(flux.row_mut(self.jetamomentum))
+            .and(self.prim.row(self.jxivelocity))
+            .and(self.cons.row(self.jetamomentum))
+            .for_each(|eta_momentum_flux, &xi_velocity, &eta_momentum| *eta_momentum_flux = xi_velocity * eta_momentum);
     }
 }

--- a/src/timeintegration/rkf.rs
+++ b/src/timeintegration/rkf.rs
@@ -206,11 +206,9 @@ impl<const S: usize, const EQ: usize> RungeKuttaFehlberg<S, EQ> {
                 for j in 0..EQ {
                     for i in 2..S - 2 {
                         err_max = err_max.max(
-                            (self.utilde.cons[[j, i]]
-                                - self.u_cons_low[[j, i]]
-                                    / (self.asc_relative_tolerance
-                                        * (self.utilde.cons[[j, i]] + self.asc_absolute_tolerance).abs()))
-                            .abs(),
+                            (self.utilde.cons[[j, i]] - self.u_cons_low[[j, i]]).abs()
+                                / (self.asc_relative_tolerance
+                                    * (self.utilde.cons[[j, i]] + self.asc_absolute_tolerance).abs()),
                         );
                     }
                 }

--- a/src/timeintegration/timestep.rs
+++ b/src/timeintegration/timestep.rs
@@ -36,7 +36,7 @@ pub struct TimeStep {
     pub dt: f64,
 
     /// Minimum value for `dt`; the simulation will error out if `dt` dips below this value
-    dt_min: f64,
+    pub dt_min: f64,
 
     /// Maximum value for `dt`; simply a safety measure if a good value for `dt_cfl_param` is not
     /// known yet for this simulation


### PR DESCRIPTION
Went through the codebase and benchmarked a couple of implementations regarding loop-able computations. Most `for` loops have been eliminated, some `.assign` calls are now `ndarray::Zip`s, and outputs now write in parallel.

Next step in this department would be to try running the output async to the rest of the loop.