### PR TITLE
Variables + generic traits

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -135,7 +135,7 @@ fn get_config(mode: usize) -> CorriesConfig {
     };
 }
 
-fn init_noh<P: Physics, const E: usize, const S: usize>(u: &mut P) {
+fn init_noh<P: Physics<E, S>, const E: usize, const S: usize>(u: &mut P) {
     let breakpoint_index = (S as f64 * 0.5) as usize;
     let mut prim = Array2::zeros((E, S));
     prim.fill(0.0);
@@ -151,9 +151,9 @@ fn init_noh<P: Physics, const E: usize, const S: usize>(u: &mut P) {
         prim.row_mut(E - 1).fill(1.0E-5)
     } else {
         let c_sound = Array1::ones(S);
-        u.assign_c_sound(&c_sound.view());
+        u.cent_mut().c_sound.assign(&c_sound.view());
     }
-    u.assign_prim(&prim.view());
+    u.cent_mut().prim.assign(&prim.view());
     return;
 }
 
@@ -163,7 +163,7 @@ pub fn noh_run(c: &mut Criterion) {
     set_Physics_and_E!(Euler1DAdiabatic);
     let config = get_config(EULER1D_ADIABATIC);
     type N = Hll;
-    type T = RungeKuttaFehlberg<P>;
+    type T = RungeKuttaFehlberg<P, E, S>;
 
     let (mut u, mut rhs, mut time, mesh, mut writer) = init_corries::<P, N, T, E, S>(&config).unwrap();
     init_noh::<P, E, S>(&mut u);
@@ -186,8 +186,8 @@ pub fn euler1d_isot_conversions(c: &mut Criterion) {
     group.sample_size(1000);
 
     let mut u = Euler1DIsot::<S>::new(&PHYSICS_CONFIG);
-    u.prim.row_mut(0).fill(2.0);
-    u.prim.row_mut(1).fill(3.0);
+    u.cent_mut().prim.row_mut(0).fill(2.0);
+    u.cent_mut().prim.row_mut(1).fill(3.0);
     group.bench_function("from prim to cons and back; euler 1d isot", |b| {
         b.iter(|| {
             u.update_cons();
@@ -196,9 +196,9 @@ pub fn euler1d_isot_conversions(c: &mut Criterion) {
     });
 
     let mut u = Euler1DAdiabatic::<S>::new(&PHYSICS_CONFIG);
-    u.prim.row_mut(0).fill(2.0);
-    u.prim.row_mut(1).fill(3.0);
-    u.prim.row_mut(2).fill(4.0);
+    u.cent_mut().prim.row_mut(0).fill(2.0);
+    u.cent_mut().prim.row_mut(1).fill(3.0);
+    u.cent_mut().prim.row_mut(2).fill(4.0);
     group.bench_function("from prim to cons and back; euler 1d adiabatic", |b| {
         b.iter(|| {
             u.update_cons();

--- a/examples/template.rs
+++ b/examples/template.rs
@@ -11,7 +11,7 @@ use corries::prelude::*;
 
 const S: usize = 10;
 set_Physics_and_E!(Euler1DIsot);
-type N = Hll;
+type N = Hll<E, S>;
 type T = RungeKuttaFehlberg<P, E, S>;
 
 fn main() -> Result<()> {

--- a/examples/template.rs
+++ b/examples/template.rs
@@ -12,7 +12,7 @@ use corries::prelude::*;
 const S: usize = 10;
 set_Physics_and_E!(Euler1DIsot);
 type N = Hll;
-type T = RungeKuttaFehlberg<P>;
+type T = RungeKuttaFehlberg<P, E, S>;
 
 fn main() -> Result<()> {
     let config: CorriesConfig = CorriesConfig {

--- a/src/boundaryconditions.rs
+++ b/src/boundaryconditions.rs
@@ -4,7 +4,7 @@
 
 //! Exports the [BoundaryCondition] trait and [init_boundary_condition] function.
 
-use crate::{mesh::Mesh, BoundaryMode, CorriesConfig, Physics};
+use crate::{mesh::Mesh, variables::Variables, BoundaryMode, CorriesConfig};
 
 use self::custom::CustomBoundaryConditions;
 
@@ -20,16 +20,15 @@ pub enum Direction {
 }
 
 /// Identifies an object that can apply boundary condition to a `Physics` object
-pub trait BoundaryCondition<P, const S: usize> {
-    //<const S: usize, const EQ: usize> {
+pub trait BoundaryCondition<const E: usize, const S: usize> {
     /// Applies the condition
-    fn apply(&mut self, u: &mut P, mesh: &Mesh<S>);
+    fn apply(&mut self, vars: &mut Variables<E, S>, mesh: &Mesh<S>);
 }
 
-pub fn init_boundary_condition<P: Physics, const S: usize>(
+pub fn init_boundary_condition<const E: usize, const S: usize>(
     direction: Direction,
     config: &CorriesConfig,
-) -> impl BoundaryCondition<P, S> {
+) -> impl BoundaryCondition<E, S> {
     return match direction {
         Direction::West => match &config.boundary_condition_west {
             BoundaryMode::Custom(v) => CustomBoundaryConditions::new(direction, v),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ pub fn init_corries<P, N, T, const E: usize, const S: usize>(
 ) -> Result<(P, Rhs<N, E, S>, Time<P, T, E, S>, Mesh<S>, Writer)>
 where
     P: Physics<E, S> + Collectable + 'static,
-    N: NumFlux,
+    N: NumFlux<E, S>,
     T: TimeSolver<P, E, S>,
 {
     if cfg!(feature = "validation") {
@@ -101,7 +101,7 @@ where
 /// * `writer` - Deals with writing output
 pub fn run_corries<
     P: Physics<E, S> + Collectable,
-    N: NumFlux,
+    N: NumFlux<E, S>,
     T: TimeSolver<P, E, S>,
     const E: usize,
     const S: usize,

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -18,6 +18,7 @@ use crate::{
 };
 
 pub mod systems;
+pub mod variables;
 
 pub use systems::*;
 

--- a/src/physics/variables.rs
+++ b/src/physics/variables.rs
@@ -4,7 +4,9 @@
 
 //! TODO
 
-use ndarray::{Array1, Array2};
+use ndarray::{Array1, Array2, ArrayView1, ArrayView2};
+
+use crate::PhysicsConfig;
 
 /// Contains the variables of a physics system
 #[derive(Debug)]
@@ -23,58 +25,98 @@ pub struct Variables<const E: usize, const S: usize> {
 
     /// Physical flux
     pub flux: Array2<f64>,
+
+    /// Adiabatic index
+    pub gamma: f64,
 }
 
 impl<const E: usize, const S: usize> Variables<E, S> {
-    pub fn new() -> Self {
+    pub fn new(physics_config: &PhysicsConfig) -> Self {
         return Variables {
             prim: Array2::zeros((E, S)),
             cons: Array2::zeros((E, S)),
             c_sound: Array1::zeros(S),
             eigen_vals: Array2::zeros((E, S)),
             flux: Array2::zeros((E, S)),
+            gamma: physics_config.adiabatic_index,
         };
     }
 
-    pub fn prim_entry(&self, j: usize, i: usize) -> f64;
-}
+    /// Return copy of the primitive variable in row j at column i
+    #[inline(always)]
+    pub fn prim_entry(&self, j: usize, i: usize) -> f64 {
+        return self.prim[[j, i]];
+    }
 
-// /// Return copy of the primitive variable in row j at column i
-// fn prim_entry(&self, j: usize, i: usize) -> f64;
-//
-// /// Return a view of the row j of the primitive variables
-// fn prim_row(&self, j: usize) -> ArrayView1<f64>;
-//
-// /// Return a view of primitive variables
-// fn prim(&self) -> ArrayView2<f64>;
-//
-// /// Return copy of the conservative variable in row j at column i
-// fn cons_entry(&self, j: usize, i: usize) -> f64;
-//
-// /// Return a view of the row j of the conservative variables
-// fn cons_row(&self, j: usize) -> ArrayView1<f64>;
-//
-// /// Return a view of conservative variables
-// fn cons(&self) -> ArrayView2<f64>;
-//
-// /// Return a view of eigen value matrix
-// fn eigen_vals(&self) -> ArrayView2<f64>;
-//
-// /// Return a view of the vector of minimal eigen values
-// fn eigen_min(&self) -> ArrayView1<f64>;
-//
-// /// Return a view of the vector of maximal eigen values
-// fn eigen_max(&self) -> ArrayView1<f64>;
-//
-// /// Return a view of speed of sound vector
-// fn c_sound(&self) -> ArrayView1<f64>;
-//
-// /// Return copy of the physical flux in row j at column i
-// fn flux_entry(&self, j: usize, i: usize) -> f64;
-//
-// /// Return a view of the row j of the physical flux
-// fn flux_row(&self, j: usize) -> ArrayView1<f64>;
-//
-// /// Return a view of the physical flux
-// fn flux(&self) -> ArrayView2<f64>;
-//
+    /// Return a view of the row j of the primitive variables
+    #[inline(always)]
+    pub fn prim_row(&self, j: usize) -> ArrayView1<f64> {
+        return self.prim.row(j);
+    }
+
+    /// Return a view of primitive variables
+    #[inline(always)]
+    pub fn prim(&self) -> ArrayView2<f64> {
+        return self.prim.view();
+    }
+
+    /// Return copy of the conservative variable in row j at column i
+    #[inline(always)]
+    pub fn cons_entry(&self, j: usize, i: usize) -> f64 {
+        return self.cons[[j, i]];
+    }
+
+    /// Return a view of the row j of the conservative variables
+    #[inline(always)]
+    pub fn cons_row(&self, j: usize) -> ArrayView1<f64> {
+        return self.cons.row(j);
+    }
+
+    /// Return a view of conservative variables
+    #[inline(always)]
+    pub fn cons(&self) -> ArrayView2<f64> {
+        return self.cons.view();
+    }
+
+    /// Return a view of eigen value matrix
+    #[inline(always)]
+    pub fn eigen_vals(&self) -> ArrayView2<f64> {
+        return self.eigen_vals.view();
+    }
+
+    /// Return a view of the vector of minimal eigen values
+    #[inline(always)]
+    pub fn eigen_min(&self) -> ArrayView1<f64> {
+        return self.eigen_vals.row(0);
+    }
+
+    /// Return a view of the vector of maximal eigen values
+    #[inline(always)]
+    pub fn eigen_max(&self) -> ArrayView1<f64> {
+        return self.eigen_vals.row(E-1);
+    }
+
+    /// Return a view of speed of sound vector
+    #[inline(always)]
+    pub fn c_sound(&self) -> ArrayView1<f64> {
+        return self.c_sound.view();
+    }
+
+    /// Return copy of the physical flux in row j at column i
+    #[inline(always)]
+    pub fn flux_entry(&self, j: usize, i: usize) -> f64 {
+        return self.flux[[j, i]];
+    }
+
+    /// Return a view of the row j of the physical flux
+    #[inline(always)]
+    pub fn flux_row(&self, j: usize) -> ArrayView1<f64> {
+        return self.flux.row(j);
+    }
+
+    /// Return a view of the physical flux
+    #[inline(always)]
+    pub fn flux(&self) -> ArrayView2<f64> {
+        return self.flux.view();
+    }
+}

--- a/src/physics/variables.rs
+++ b/src/physics/variables.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2023
+// Author: Tommy Breslein (github.com/tbreslein)
+// License: MIT
+
+//! TODO
+
+use ndarray::{Array1, Array2};
+
+/// Contains the variables of a physics system
+#[derive(Debug)]
+pub struct Variables<const E: usize, const S: usize> {
+    /// Primitive variables
+    pub prim: Array2<f64>,
+
+    /// Conservative variables
+    pub cons: Array2<f64>,
+
+    /// Speed of sound
+    pub c_sound: Array1<f64>,
+
+    /// Eigen values
+    pub eigen_vals: Array2<f64>,
+
+    /// Physical flux
+    pub flux: Array2<f64>,
+}
+
+impl<const E: usize, const S: usize> Variables<E, S> {
+    pub fn new() -> Self {
+        return Variables {
+            prim: Array2::zeros((E, S)),
+            cons: Array2::zeros((E, S)),
+            c_sound: Array1::zeros(S),
+            eigen_vals: Array2::zeros((E, S)),
+            flux: Array2::zeros((E, S)),
+        };
+    }
+
+    pub fn prim_entry(&self, j: usize, i: usize) -> f64;
+}
+
+// /// Return copy of the primitive variable in row j at column i
+// fn prim_entry(&self, j: usize, i: usize) -> f64;
+//
+// /// Return a view of the row j of the primitive variables
+// fn prim_row(&self, j: usize) -> ArrayView1<f64>;
+//
+// /// Return a view of primitive variables
+// fn prim(&self) -> ArrayView2<f64>;
+//
+// /// Return copy of the conservative variable in row j at column i
+// fn cons_entry(&self, j: usize, i: usize) -> f64;
+//
+// /// Return a view of the row j of the conservative variables
+// fn cons_row(&self, j: usize) -> ArrayView1<f64>;
+//
+// /// Return a view of conservative variables
+// fn cons(&self) -> ArrayView2<f64>;
+//
+// /// Return a view of eigen value matrix
+// fn eigen_vals(&self) -> ArrayView2<f64>;
+//
+// /// Return a view of the vector of minimal eigen values
+// fn eigen_min(&self) -> ArrayView1<f64>;
+//
+// /// Return a view of the vector of maximal eigen values
+// fn eigen_max(&self) -> ArrayView1<f64>;
+//
+// /// Return a view of speed of sound vector
+// fn c_sound(&self) -> ArrayView1<f64>;
+//
+// /// Return copy of the physical flux in row j at column i
+// fn flux_entry(&self, j: usize, i: usize) -> f64;
+//
+// /// Return a view of the row j of the physical flux
+// fn flux_row(&self, j: usize) -> ArrayView1<f64>;
+//
+// /// Return a view of the physical flux
+// fn flux(&self) -> ArrayView2<f64>;
+//

--- a/src/physics/variables.rs
+++ b/src/physics/variables.rs
@@ -8,7 +8,7 @@ use color_eyre::{
     eyre::{bail, ensure},
     Result,
 };
-use ndarray::{Array1, Array2};
+use ndarray::{Array1, Array2, ArrayView1};
 
 use crate::{errorhandling::Validation, Collectable, Data, DataName, PhysicsConfig, StructAssociation};
 
@@ -51,6 +51,14 @@ impl<const E: usize, const S: usize> Variables<E, S> {
         self.cons.assign(&rhs.cons);
         self.c_sound.assign(&rhs.c_sound);
     }
+
+    pub fn eigen_min(&self) -> ArrayView1<f64> {
+        self.eigen_vals.row(0)
+    }
+
+    pub fn eigen_max(&self) -> ArrayView1<f64> {
+        self.eigen_vals.row(E - 1)
+    }
 }
 
 impl<const E: usize, const S: usize> Collectable for Variables<E, S> {
@@ -58,7 +66,9 @@ impl<const E: usize, const S: usize> Collectable for Variables<E, S> {
         match (data.association, data.name) {
             (StructAssociation::Physics, DataName::Prim(j)) => self.write_vector(&self.prim.row(j), data, mesh_offset),
             (StructAssociation::Physics, DataName::Cons(j)) => self.write_vector(&self.cons.row(j), data, mesh_offset),
-            (StructAssociation::Physics, DataName::CSound) => self.write_vector(&self.c_sound.view(), data, mesh_offset),
+            (StructAssociation::Physics, DataName::CSound) => {
+                self.write_vector(&self.c_sound.view(), data, mesh_offset)
+            },
             (StructAssociation::Physics, x) => bail!("Tried associating {:?} with Physics!", x),
             (StructAssociation::Mesh, x) | (StructAssociation::TimeStep, x) => {
                 bail!("name.association() for {:?} returned {:?}", x, data.association)

--- a/src/rhs.rs
+++ b/src/rhs.rs
@@ -21,7 +21,7 @@ pub mod numflux;
 pub use self::numflux::{hll::Hll, init_numflux, NumFlux};
 
 /// Carries objects and methods for solving the right-hand side of a set of equations.
-pub struct Rhs<P: Physics, N: NumFlux, const S: usize> {
+pub struct Rhs<N: NumFlux, const E: usize, const S: usize> {
     /// Full summed up rhs
     pub full_rhs: Array2<f64>,
 
@@ -29,13 +29,13 @@ pub struct Rhs<P: Physics, N: NumFlux, const S: usize> {
     numflux: N,
 
     /// Boundary condition operator for the west boundary
-    pub boundary_west: Box<dyn BoundaryCondition<P, S>>,
+    pub boundary_west: Box<dyn BoundaryCondition<E, S>>,
 
     /// Boundary condition operator for the east boundary
-    pub boundary_east: Box<dyn BoundaryCondition<P, S>>,
+    pub boundary_east: Box<dyn BoundaryCondition<E, S>>,
 }
 
-impl<P: Physics + 'static, N: NumFlux, const S: usize> Rhs<P, N, S> {
+impl<N: NumFlux, const E: usize, const S: usize> Rhs<N, E, S> {
     /// Constructs a new [Rhs] object.
     ///
     /// # Arguments
@@ -43,12 +43,12 @@ impl<P: Physics + 'static, N: NumFlux, const S: usize> Rhs<P, N, S> {
     /// * `config` - Configuration for the whole simulation
     /// * `u` - The main [Physics] object for this simulation
     /// * `numflux` - The [dyn NumFlux] object about to be stored in this [Rhs] object
-    pub fn new<const E: usize>(config: &CorriesConfig) -> Self {
+    pub fn new(config: &CorriesConfig) -> Self {
         return Rhs {
             full_rhs: Array2::zeros((E, S)),
             numflux: init_numflux::<N, E, S>(&config.numerics_config),
-            boundary_west: Box::new(init_boundary_condition::<P, S>(Direction::West, config)),
-            boundary_east: Box::new(init_boundary_condition::<P, S>(Direction::East, config)),
+            boundary_west: Box::new(init_boundary_condition::<E, S>(Direction::West, config)),
+            boundary_east: Box::new(init_boundary_condition::<E, S>(Direction::East, config)),
         };
     }
 
@@ -58,7 +58,7 @@ impl<P: Physics + 'static, N: NumFlux, const S: usize> Rhs<P, N, S> {
     ///
     /// * `u` - The current [Physics] state
     /// * `mesh` - Information about spatial properties
-    pub fn update<const E: usize>(&mut self, u: &mut P, mesh: &Mesh<S>) -> Result<()> {
+    pub fn update<P: Physics<E, S>>(&mut self, u: &mut P, mesh: &Mesh<S>) -> Result<()> {
         // this assumes that u.cons is up-to-date
         update_everything_from_cons(u, &mut self.boundary_west, &mut self.boundary_east, mesh);
         self.numflux
@@ -68,7 +68,7 @@ impl<P: Physics + 'static, N: NumFlux, const S: usize> Rhs<P, N, S> {
     }
 }
 
-impl<P: Physics, N: NumFlux, const S: usize> Validation for Rhs<P, N, S> {
+impl<N: NumFlux, const E: usize, const S: usize> Validation for Rhs<N, E, S> {
     fn validate(&self) -> Result<()> {
         ensure!(
             self.full_rhs.fold(true, |acc, x| acc && x.is_finite()),

--- a/src/rhs.rs
+++ b/src/rhs.rs
@@ -21,7 +21,7 @@ pub mod numflux;
 pub use self::numflux::{hll::Hll, init_numflux, NumFlux};
 
 /// Carries objects and methods for solving the right-hand side of a set of equations.
-pub struct Rhs<N: NumFlux, const E: usize, const S: usize> {
+pub struct Rhs<N: NumFlux<E, S>, const E: usize, const S: usize> {
     /// Full summed up rhs
     pub full_rhs: Array2<f64>,
 
@@ -35,7 +35,7 @@ pub struct Rhs<N: NumFlux, const E: usize, const S: usize> {
     pub boundary_east: Box<dyn BoundaryCondition<E, S>>,
 }
 
-impl<N: NumFlux, const E: usize, const S: usize> Rhs<N, E, S> {
+impl<N: NumFlux<E, S>, const E: usize, const S: usize> Rhs<N, E, S> {
     /// Constructs a new [Rhs] object.
     ///
     /// # Arguments
@@ -62,13 +62,13 @@ impl<N: NumFlux, const E: usize, const S: usize> Rhs<N, E, S> {
         // this assumes that u.cons is up-to-date
         update_everything_from_cons(u, &mut self.boundary_west, &mut self.boundary_east, mesh);
         self.numflux
-            .calc_dflux_dxi::<P, E, S>(&mut self.full_rhs, u, mesh)
+            .calc_dflux_dxi(&mut self.full_rhs, u, mesh)
             .context("Calling Rhs::numflux::calc_dflux_dxi in Rhs::update_dflux_dxi")?;
         return Ok(());
     }
 }
 
-impl<N: NumFlux, const E: usize, const S: usize> Validation for Rhs<N, E, S> {
+impl<N: NumFlux<E, S>, const E: usize, const S: usize> Validation for Rhs<N, E, S> {
     fn validate(&self) -> Result<()> {
         ensure!(
             self.full_rhs.fold(true, |acc, x| acc && x.is_finite()),

--- a/src/rhs/numflux.rs
+++ b/src/rhs/numflux.rs
@@ -14,12 +14,12 @@ pub mod hll;
 pub use self::hll::Hll;
 
 /// Trait for structs that can calculate numerical flux
-pub trait NumFlux {
+pub trait NumFlux<const E: usize, const S: usize> {
     /// construct a new trait object
-    fn new<const E: usize, const S: usize>(numerics_config: &NumericsConfig) -> Self;
+    fn new(numerics_config: &NumericsConfig) -> Self;
 
     /// Calculates the numerical derivative along the xi direction
-    fn calc_dflux_dxi<P: Physics<E, S>, const E: usize, const S: usize>(
+    fn calc_dflux_dxi<P: Physics<E, S>>(
         &mut self,
         dflux_dxi: &mut Array2<f64>,
         u: &mut P,
@@ -28,8 +28,8 @@ pub trait NumFlux {
 }
 
 /// Constructs an `impl Numflux<S, EQ>`.
-pub fn init_numflux<N: NumFlux, const E: usize, const S: usize>(numerics_config: &NumericsConfig) -> N {
-    return N::new::<E, S>(numerics_config);
+pub fn init_numflux<N: NumFlux<E, S>, const E: usize, const S: usize>(numerics_config: &NumericsConfig) -> N {
+    return N::new(numerics_config);
 }
 
 /// Generic function to calculate the derivative of the numerical flux along the xi direction.

--- a/src/rhs/numflux.rs
+++ b/src/rhs/numflux.rs
@@ -19,10 +19,10 @@ pub trait NumFlux {
     fn new<const E: usize, const S: usize>(numerics_config: &NumericsConfig) -> Self;
 
     /// Calculates the numerical derivative along the xi direction
-    fn calc_dflux_dxi<P: Physics, const E: usize, const S: usize>(
+    fn calc_dflux_dxi<P: Physics<E, S>, const E: usize, const S: usize>(
         &mut self,
         dflux_dxi: &mut Array2<f64>,
-        u: &P,
+        u: &mut P,
         mesh: &Mesh<S>,
     ) -> Result<()>;
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -61,7 +61,7 @@ pub trait TimeSolver<P: Physics<E, S>, const E: usize, const S: usize> {
     /// * `u` - The current physical state
     /// * `rhs` - Solves the right-hand side
     /// * `mesh` - Information about spatial properties
-    fn next_solution<N: NumFlux>(
+    fn next_solution<N: NumFlux<E, S>>(
         &mut self,
         time: &mut TimeStep,
         u: &mut P,
@@ -106,7 +106,7 @@ impl<P: Physics<E, S>, T: TimeSolver<P, E, S>, const E: usize, const S: usize> T
     /// * `u` - the [Physics] state being modified to transition between current and next state
     /// * `rhs` - solves the right-hand side
     /// * `mesh` - Information about spatial properties
-    pub fn next_solution<N: NumFlux>(&mut self, u: &mut P, rhs: &mut Rhs<N, E, S>, mesh: &Mesh<S>) -> Result<()> {
+    pub fn next_solution<N: NumFlux<E, S>>(&mut self, u: &mut P, rhs: &mut Rhs<N, E, S>, mesh: &Mesh<S>) -> Result<()> {
         self.solver
             .next_solution::<N>(&mut self.timestep, u, rhs, mesh)
             .context("Calling TimeIntegration::solver.next_solution in TimeIntegration::next_solution")?;

--- a/src/time.rs
+++ b/src/time.rs
@@ -42,14 +42,14 @@ impl Display for DtKind {
 }
 
 /// Trait for objects that solve the time integration step and produce new solutions
-pub trait TimeSolver<P: Physics> {
+pub trait TimeSolver<P: Physics<E, S>, const E: usize, const S: usize> {
     /// Constructs a new [TimeSolver] object
     ///
     /// # Arguments
     ///
     /// * `rkfconfig` - Configuration specifically for [RungeKuttaFehlberg] objects
     /// * `physicsconfig` - Configuration for [Physics] objects, needed because `utilde`
-    fn new<const E: usize, const S: usize>(config: &CorriesConfig, u: &P) -> Result<Self>
+    fn new(config: &CorriesConfig, u: &P) -> Result<Self>
     where
         Self: Sized;
 
@@ -61,11 +61,11 @@ pub trait TimeSolver<P: Physics> {
     /// * `u` - The current physical state
     /// * `rhs` - Solves the right-hand side
     /// * `mesh` - Information about spatial properties
-    fn next_solution<N: NumFlux, const E: usize, const S: usize>(
+    fn next_solution<N: NumFlux>(
         &mut self,
         time: &mut TimeStep,
         u: &mut P,
-        rhs: &mut Rhs<P, N, S>,
+        rhs: &mut Rhs<N, E, S>,
         mesh: &Mesh<S>,
     ) -> Result<()>;
 }
@@ -74,7 +74,7 @@ pub trait TimeSolver<P: Physics> {
 ///
 /// Carries a [TimeStep] for keeping track of the time coordinate and data regarding it, as well as
 /// a `Box<dyn TimeSolver>` for calculating new solutions.
-pub struct Time<P: Physics, T: TimeSolver<P>> {
+pub struct Time<P: Physics<E, S>, T: TimeSolver<P, E, S>, const E: usize, const S: usize> {
     /// Keeps track of the time coordinate and related data
     pub timestep: TimeStep,
 
@@ -84,14 +84,14 @@ pub struct Time<P: Physics, T: TimeSolver<P>> {
     embedded_type: PhantomData<P>,
 }
 
-impl<P: Physics, T: TimeSolver<P>> Time<P, T> {
+impl<P: Physics<E, S>, T: TimeSolver<P, E, S>, const E: usize, const S: usize> Time<P, T, E, S> {
     /// Constructs a new [Time] struct.
     ///
     /// # Arguments
     ///
     /// * `config` - a [CorriesConfig] configuration object
-    pub fn new<const E: usize, const S: usize>(config: &CorriesConfig, u: &P) -> Result<Self> {
-        let solver = T::new::<E, S>(config, u)?;
+    pub fn new(config: &CorriesConfig, u: &P) -> Result<Self> {
+        let solver = T::new(config, u)?;
         return Ok(Self {
             timestep: TimeStep::new(&config.numerics_config, config.output_counter_max),
             solver,
@@ -106,14 +106,9 @@ impl<P: Physics, T: TimeSolver<P>> Time<P, T> {
     /// * `u` - the [Physics] state being modified to transition between current and next state
     /// * `rhs` - solves the right-hand side
     /// * `mesh` - Information about spatial properties
-    pub fn next_solution<N: NumFlux, const E: usize, const S: usize>(
-        &mut self,
-        u: &mut P,
-        rhs: &mut Rhs<P, N, S>,
-        mesh: &Mesh<S>,
-    ) -> Result<()> {
+    pub fn next_solution<N: NumFlux>(&mut self, u: &mut P, rhs: &mut Rhs<N, E, S>, mesh: &Mesh<S>) -> Result<()> {
         self.solver
-            .next_solution::<N, E, S>(&mut self.timestep, u, rhs, mesh)
+            .next_solution::<N>(&mut self.timestep, u, rhs, mesh)
             .context("Calling TimeIntegration::solver.next_solution in TimeIntegration::next_solution")?;
         if self.timestep.iter >= self.timestep.iter_max {
             bail!(

--- a/src/time/rkf.rs
+++ b/src/time/rkf.rs
@@ -101,7 +101,7 @@ impl<P: Physics<E, S> + Validation + 'static, const E: usize, const S: usize> Ti
         });
     }
 
-    fn next_solution<N: NumFlux>(
+    fn next_solution<N: NumFlux<E, S>>(
         &mut self,
         time: &mut TimeStep,
         u: &mut P,
@@ -155,7 +155,7 @@ impl<P: Physics<E, S> + Validation + 'static, const E: usize, const S: usize> Ru
     /// * `u` - Input [Physics] state
     /// * `rhs` - Solves the right-hand side
     /// * `mesh` - Information about spatial properties
-    fn calc_rkf_solution<N: NumFlux>(
+    fn calc_rkf_solution<N: NumFlux<E, S>>(
         &mut self,
         dt_in: f64,
         u: &mut P,

--- a/src/time/timestep.rs
+++ b/src/time/timestep.rs
@@ -87,14 +87,14 @@ impl TimeStep {
     ///
     /// * `u` - The current [Physics] state
     /// * `mesh` - Information about spatial properties
-    pub fn calc_dt_expl<P: Physics, const S: usize>(
+    pub fn calc_dt_expl<P: Physics<E, S>, const E: usize, const S: usize>(
         &mut self,
         u: &mut P,
         // rhs: &Rhs<S, EQ>,
         mesh: &Mesh<S>,
     ) -> Result<()> {
         //TODO: source term time steps
-        self.dt = u.calc_dt_cfl(self.dt_cfl_param, mesh)?;
+        self.dt = u.calc_dt_cfl(&u.cent().eigen_max(), self.dt_cfl_param, mesh)?;
         if self.dt < self.dt_min {
             bail!(
                 "Time step width dt dipped below dt_min! Got dt = {}, dt_min = {}",

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -78,10 +78,10 @@ impl Writer {
     /// * `u` - Provides data for the state of the simulation
     /// * `time` - Provides data on the time coordinates
     /// * `mesh` - Provides mesh data
-    pub fn update_data<P: Physics + Collectable, T: TimeSolver<P>, const S: usize>(
+    pub fn update_data<P: Physics<E, S> + Collectable, T: TimeSolver<P, E, S>, const E: usize, const S: usize>(
         &mut self,
         u: &P,
-        time: &Time<P, T>,
+        time: &Time<P, T, E, S>,
         mesh: &Mesh<S>,
     ) -> Result<()> {
         self.outputs

--- a/src/writer/output.rs
+++ b/src/writer/output.rs
@@ -154,10 +154,10 @@ impl Output {
     /// * `u` - Provides data for the state of the simulation
     /// * `time` - Provides data on the time coordinates
     /// * `mesh` - Provides mesh data
-    pub fn update_data<P: Physics + Collectable, T: TimeSolver<P>, const S: usize>(
+    pub fn update_data<P: Physics<E, S> + Collectable, T: TimeSolver<P, E, S>, const E: usize, const S: usize>(
         &mut self,
         u: &P,
-        time: &Time<P, T>,
+        time: &Time<P, T, E, S>,
         mesh: &Mesh<S>,
     ) -> Result<()> {
         self.data.iter_mut().try_for_each(|data| match data.association {

--- a/tests/noh.rs
+++ b/tests/noh.rs
@@ -134,7 +134,7 @@ fn get_config(mode: usize) -> CorriesConfig {
     };
 }
 
-fn init_noh<P: Physics, const E: usize, const S: usize>(u: &mut P) {
+fn init_noh<P: Physics<E, S>, const E: usize, const S: usize>(u: &mut P) {
     let breakpoint_index = (S as f64 * 0.5) as usize;
     let mut prim = Array2::ones((E, S));
     for i in breakpoint_index..S {
@@ -143,9 +143,9 @@ fn init_noh<P: Physics, const E: usize, const S: usize>(u: &mut P) {
     if u.is_adiabatic() {
         prim.row_mut(E - 1).fill(1.0E-5);
     } else {
-        u.assign_c_sound(&Array1::ones(S).view());
+        u.cent_mut().c_sound.assign(&Array1::ones(S).view());
     }
-    u.assign_prim(&prim.view());
+    u.cent_mut().prim.assign(&prim.view());
     return;
 }
 
@@ -153,13 +153,13 @@ fn init_noh<P: Physics, const E: usize, const S: usize>(u: &mut P) {
 fn noh_euler1d_adiabatic() -> Result<()> {
     set_Physics_and_E!(Euler1DAdiabatic);
     type N = Hll;
-    type T = RungeKuttaFehlberg<P>;
+    type T = RungeKuttaFehlberg<P, E, S>;
 
     let config = get_config(EULER1D_ADIABATIC);
     let mesh: Mesh<S> = Mesh::new(&config.mesh_config).context("Constructing Mesh")?;
     let mut u: P = P::new(&config.physics_config);
-    let mut rhs: Rhs<P, N, S> = Rhs::<P, N, S>::new::<E>(&config);
-    let mut time: Time<P, T> = Time::new::<E, S>(&config, &u)?;
+    let mut rhs: Rhs<N, E, S> = Rhs::<N, E, S>::new(&config);
+    let mut time: Time<P, T, E, S> = Time::new(&config, &u)?;
     let mut writer = Writer::new::<S>(&config, &mesh)?;
 
     init_noh::<P, E, S>(&mut u);
@@ -174,13 +174,13 @@ fn noh_euler1d_adiabatic() -> Result<()> {
 fn noh_euler1d_isot() -> Result<()> {
     set_Physics_and_E!(Euler1DIsot);
     type N = Hll;
-    type T = RungeKuttaFehlberg<P>;
+    type T = RungeKuttaFehlberg<P, E, S>;
 
     let config = get_config(EULER1D_ISOT);
     let mesh: Mesh<S> = Mesh::new(&config.mesh_config).context("Constructing Mesh")?;
     let mut u: P = P::new(&config.physics_config);
-    let mut rhs: Rhs<P, N, S> = Rhs::<P, N, S>::new::<E>(&config);
-    let mut time: Time<P, T> = Time::new::<E, S>(&config, &u)?;
+    let mut rhs: Rhs<N, E, S> = Rhs::<N, E, S>::new(&config);
+    let mut time: Time<P, T, E, S> = Time::new(&config, &u)?;
     let mut writer = Writer::new::<S>(&config, &mesh)?;
 
     init_noh::<P, E, S>(&mut u);

--- a/tests/noh.rs
+++ b/tests/noh.rs
@@ -152,7 +152,7 @@ fn init_noh<P: Physics<E, S>, const E: usize, const S: usize>(u: &mut P) {
 #[test]
 fn noh_euler1d_adiabatic() -> Result<()> {
     set_Physics_and_E!(Euler1DAdiabatic);
-    type N = Hll;
+    type N = Hll<E, S>;
     type T = RungeKuttaFehlberg<P, E, S>;
 
     let config = get_config(EULER1D_ADIABATIC);
@@ -173,7 +173,7 @@ fn noh_euler1d_adiabatic() -> Result<()> {
 #[test]
 fn noh_euler1d_isot() -> Result<()> {
     set_Physics_and_E!(Euler1DIsot);
-    type N = Hll;
+    type N = Hll<E, S>;
     type T = RungeKuttaFehlberg<P, E, S>;
 
     let config = get_config(EULER1D_ISOT);

--- a/tests/sod.rs
+++ b/tests/sod.rs
@@ -114,7 +114,7 @@ fn init<P: Physics<E, S>, const E: usize, const S: usize>(u: &mut P) {
 #[test]
 fn sod_hll() -> Result<()> {
     set_Physics_and_E!(Euler1DAdiabatic);
-    type N = Hll;
+    type N = Hll<E, S>;
     type T = RungeKuttaFehlberg<P, E, S>;
 
     let config = get_config(NumFluxMode::Hll);

--- a/tests/sod.rs
+++ b/tests/sod.rs
@@ -96,7 +96,7 @@ fn get_config(mode: NumFluxMode) -> CorriesConfig {
     };
 }
 
-fn init<P: Physics, const E: usize, const S: usize>(u: &mut P) {
+fn init<P: Physics<E, S>, const E: usize, const S: usize>(u: &mut P) {
     let breakpoint_index = (S as f64 * 0.5) as usize;
     let mut prim = Array2::zeros((E, S));
     for i in 0..breakpoint_index {
@@ -107,7 +107,7 @@ fn init<P: Physics, const E: usize, const S: usize>(u: &mut P) {
         prim[[0, i]] = 0.125;
         prim[[E - 1, i]] = 0.1;
     }
-    u.assign_prim(&prim.view());
+    u.cent_mut().prim.assign(&prim.view());
     return;
 }
 
@@ -115,13 +115,13 @@ fn init<P: Physics, const E: usize, const S: usize>(u: &mut P) {
 fn sod_hll() -> Result<()> {
     set_Physics_and_E!(Euler1DAdiabatic);
     type N = Hll;
-    type T = RungeKuttaFehlberg<P>;
+    type T = RungeKuttaFehlberg<P, E, S>;
 
     let config = get_config(NumFluxMode::Hll);
     let mesh: Mesh<S> = Mesh::new(&config.mesh_config).context("Constructing Mesh")?;
     let mut u: P = P::new(&config.physics_config);
-    let mut rhs: Rhs<P, N, S> = Rhs::<P, N, S>::new::<E>(&config);
-    let mut time: Time<P, T> = Time::new::<E, S>(&config, &u)?;
+    let mut rhs: Rhs<N, E, S> = Rhs::<N, E, S>::new(&config);
+    let mut time: Time<P, T, E, S> = Time::new(&config, &u)?;
     let mut writer = Writer::new::<S>(&config, &mesh)?;
 
     init::<P, E, S>(&mut u);


### PR DESCRIPTION
This PR:

- adds the `Variables` struct:
  - this abstracts the values of structs implementing `Physics` into their own accessors, usually stored in their own fields
  - makes it easy to differentiate between cell centered, west aligned and east aligned variable sets (as implemented for `Euler1DIsot` and `Euler1DAdiabatic`); this is needed for implementing the KT numerical flux solver next
- turns `Physics` and `NumFlux` into traits with the generic dimension parameters `E` and `S` baked in
  - this makes makes parameter deduction easier in some instances, and removes the necessity for parameters for some methods altogether
  - This comes at the cost of making `Physics` and `NumFlux` more complex, thus making function signatures more verbose