### PR TITLE
Add Directions enums

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -128,7 +128,7 @@ pub fn noh_hll_run(c: &mut Criterion) {
 
     let (mut u, mut rhs, mut time, mesh, mut writer) = init_corries::<P, N, T, E, S>(&config).unwrap();
     init_noh::<P, E, S>(&mut u);
-    u.update_cent_from_prim(&mut rhs.boundary_west, &mut rhs.boundary_east, &mesh);
+    u.update_vars_from_prim(&mut rhs.boundary_west, &mut rhs.boundary_east, &mesh);
 
     group.bench_function("noh_hll", |b| {
         b.iter(|| {
@@ -150,7 +150,7 @@ pub fn noh_kt_run(c: &mut Criterion) {
 
     let (mut u, mut rhs, mut time, mesh, mut writer) = init_corries::<P, N, T, E, S>(&config).unwrap();
     init_noh::<P, E, S>(&mut u);
-    u.update_cent_from_prim(&mut rhs.boundary_west, &mut rhs.boundary_east, &mesh);
+    u.update_vars_from_prim(&mut rhs.boundary_west, &mut rhs.boundary_east, &mesh);
     u.init_west_east();
 
     group.bench_function("noh_kt", |b| {
@@ -174,8 +174,8 @@ pub fn euler1d_isot_conversions(c: &mut Criterion) {
     u.cent.prim.row_mut(1).fill(3.0);
     group.bench_function("from prim to cons and back; euler 1d isot", |b| {
         b.iter(|| {
-            u.update_cons_cent();
-            u.update_prim_cent();
+            u.update_cons();
+            u.update_prim();
         })
     });
 
@@ -185,8 +185,8 @@ pub fn euler1d_isot_conversions(c: &mut Criterion) {
     u.cent.prim.row_mut(2).fill(4.0);
     group.bench_function("from prim to cons and back; euler 1d adiabatic", |b| {
         b.iter(|| {
-            u.update_cons_cent();
-            u.update_prim_cent();
+            u.update_cons();
+            u.update_prim();
         })
     });
 

--- a/src/directions.rs
+++ b/src/directions.rs
@@ -1,0 +1,16 @@
+// Copyright (c) 2022-2023
+// Author: Tommy Breslein (github.com/tbreslein)
+// License: MIT
+
+//! Exports the [Directions] enum
+
+/// Enumerates the different directions inside a cell we can pull values from
+#[repr(u8)]
+pub enum Direction {
+    /// west facing cell face
+    West,
+    /// cell centre
+    Cent,
+    /// east facing cell face
+    East,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod config;
 mod errorhandling;
 #[macro_use]
 pub mod macros;
+pub mod directions;
 pub mod mesh;
 pub mod rhs;
 pub mod state;
@@ -38,6 +39,7 @@ pub mod writer;
 /// as well as the [set_Physics_and_E] macro, and the [run_corries] function
 pub mod prelude {
     pub use crate::config::*;
+    pub use crate::directions::*;
     pub use crate::init_corries;
     pub use crate::mesh::*;
     pub use crate::rhs::*;

--- a/src/rhs.rs
+++ b/src/rhs.rs
@@ -62,7 +62,7 @@ impl<N: NumFlux<E, S>, const E: usize, const S: usize> Rhs<N, E, S> {
     /// * `mesh` - Information about spatial properties
     pub fn update<P: Physics<E, S>>(&mut self, u: &mut State<P, E, S>, mesh: &Mesh<S>) -> Result<()> {
         // this assumes that u.cons is up-to-date
-        u.update_cent_from_cons(&mut self.boundary_west, &mut self.boundary_east, mesh);
+        u.update_vars_from_cons(&mut self.boundary_west, &mut self.boundary_east, mesh);
         self.numflux
             .calc_dflux_dxi(&mut self.full_rhs, u, mesh)
             .context("Calling Rhs::numflux::calc_dflux_dxi in Rhs::update_dflux_dxi")?;

--- a/src/rhs/numflux/hll.rs
+++ b/src/rhs/numflux/hll.rs
@@ -54,7 +54,7 @@ impl<const E: usize, const S: usize> NumFlux<E, S> for Hll<E, S> {
         mesh: &Mesh<S>,
     ) -> Result<()> {
         // NOTE: Assumes that u.eigen_vals are already up to date
-        u.update_flux_cent();
+        u.update_flux();
 
         let uflux = &u.cent.flux;
         let ucons = &u.cent.cons;
@@ -179,8 +179,8 @@ mod tests {
         let mesh: Mesh<S> = Mesh::new(&MESHCONFIG).unwrap();
         let mut u = State::<P, E, S>::new(&PHYSICSCONFIG);
         init_noh(&mut u);
-        u.update_cons_cent();
-        u.update_derived_variables_cent();
+        u.update_cons();
+        u.update_derived_variables();
         let mut hll: Hll<E, S> = Hll::new(&NumFluxConfig::Hll, &mesh).unwrap();
 
         let dflux_dxi_prim_expect = Array2::from_shape_vec(

--- a/src/rhs/numflux/kt.rs
+++ b/src/rhs/numflux/kt.rs
@@ -8,6 +8,7 @@ use color_eyre::eyre::{bail, ensure, Context};
 use color_eyre::Result;
 use ndarray::{par_azip, s, Array1, Array2};
 
+use crate::directions::Direction;
 use crate::errorhandling::Validation;
 use crate::{mesh::Mesh, state::Physics};
 use crate::{LimiterMode, NumFluxConfig, State};
@@ -99,16 +100,16 @@ impl<const E: usize, const S: usize> NumFlux<E, S> for Kt<E, S> {
         // NOTE: Assumes that u.cons is already up to date
         self.reconstruct(u);
 
-        u.update_prim_west();
-        u.update_prim_east();
-        u.update_c_sound_west();
-        u.update_c_sound_east();
-        u.update_eigen_vals_min_west();
-        u.update_eigen_vals_min_east();
-        u.update_eigen_vals_max_west();
-        u.update_eigen_vals_max_east();
-        u.update_flux_west();
-        u.update_flux_east();
+        u.update_prim_d::<{ Direction::West as u8 }>();
+        u.update_prim_d::<{ Direction::East as u8 }>();
+        u.update_c_sound_d::<{ Direction::West as u8 }>();
+        u.update_c_sound_d::<{ Direction::East as u8 }>();
+        u.update_eigen_vals_min_d::<{ Direction::West as u8 }>();
+        u.update_eigen_vals_min_d::<{ Direction::East as u8 }>();
+        u.update_eigen_vals_max_d::<{ Direction::West as u8 }>();
+        u.update_eigen_vals_max_d::<{ Direction::East as u8 }>();
+        u.update_flux_d::<{ Direction::West as u8 }>();
+        u.update_flux_d::<{ Direction::East as u8 }>();
 
         let eigen_min_west = &u.west.eigen_min();
         let eigen_min_east = &u.east.eigen_min();
@@ -295,8 +296,8 @@ mod tests {
         let mesh: Mesh<S> = Mesh::new(&MESHCONFIG).unwrap();
         let mut u = State::<P, E, S>::new(&PHYSICSCONFIG);
         init_noh(&mut u);
-        u.update_cons_cent();
-        u.update_derived_variables_cent();
+        u.update_cons();
+        u.update_derived_variables();
         u.init_west_east();
         let mut kt = Kt::new(
             &NumFluxConfig::Kt {

--- a/src/state.rs
+++ b/src/state.rs
@@ -59,24 +59,22 @@ impl<P: Physics<E, S>, const E: usize, const S: usize> State<P, E, S> {
     }
 
     const fn get_vars<const D: u8>(&self) -> &Variables<E, S> {
-        if D == Direction::West as u8 {
-            &self.west
-        } else if D == Direction::East as u8 {
-            &self.east
-        } else {
-            &self.cent
+        match D {
+            d if d == Direction::West as u8 => &self.west,
+            d if d == Direction::Cent as u8 => &self.cent,
+            d if d == Direction::East as u8 => &self.east,
+            _ => panic!("called get vars with a template parameter that cannot be cast into from a Direction!")
         }
     }
 
     // TODO: make this a const fn, once the feature is added to rustlang to enable mut refs in
     // const contexts.
     fn get_vars_mut<const D: u8>(&mut self) -> &mut Variables<E, S> {
-        if D == Direction::West as u8 {
-            &mut self.west
-        } else if D == Direction::East as u8 {
-            &mut self.east
-        } else {
-            &mut self.cent
+        match D {
+            d if d == Direction::West as u8 => &mut self.west,
+            d if d == Direction::Cent as u8 => &mut self.cent,
+            d if d == Direction::East as u8 => &mut self.east,
+            _ => panic!("called get vars with a template parameter that cannot be cast into from a Direction!")
         }
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -12,7 +12,9 @@ use std::marker::PhantomData;
 
 use color_eyre::Result;
 
-use crate::{boundaryconditions::BoundaryCondition, errorhandling::Validation, Mesh, PhysicsConfig};
+use crate::{
+    boundaryconditions::BoundaryCondition, directions::Direction, errorhandling::Validation, Mesh, PhysicsConfig,
+};
 
 pub use self::{physics::Physics, systems::*};
 
@@ -32,17 +34,6 @@ pub struct State<P: Physics<E, S>, const E: usize, const S: usize> {
     /// Variables at the east border of each cell in the mesh
     pub east: Variables<E, S>,
     methods: PhantomData<P>,
-}
-
-/// Enumerates the different directions inside a cell we can pull values from
-#[repr(u8)]
-pub enum Direction {
-    /// west facing cell face
-    West,
-    /// cell centre
-    Cent,
-    /// east facing cell face
-    East,
 }
 
 impl<P: Physics<E, S>, const E: usize, const S: usize> State<P, E, S> {
@@ -89,7 +80,7 @@ impl<P: Physics<E, S>, const E: usize, const S: usize> State<P, E, S> {
         }
     }
 
-    /// Update the primitive variables
+    /// Update the primitive variables at a certain part of each mesh cell
     ///
     /// The template parameter denotes whether to update the cell centres, west cell faces, or east
     /// cell faces. Pass the parameter as the Direction enum cast to u8 to use this function.
@@ -98,122 +89,548 @@ impl<P: Physics<E, S>, const E: usize, const S: usize> State<P, E, S> {
     ///
     /// ```
     /// use corries::prelude::*;
-    /// let physics_config = PhysicsConfig { adiabatic_index = 1.66, units_mode = UnitsMode::SI };
-    /// let mut u: State<Euler1DIsot, E, S> = State::new(physics_config);
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
     ///
     /// // Updates the primitive variables in the cell centres
-    /// u.update_prim::<Direction::Cent as u8>();
+    /// u.update_prim_d::<{Direction::Cent as u8}>();
+    ///
+    /// // Updates the primitive variables at west cell faces
+    /// u.update_prim_d::<{Direction::West as u8}>();
+    ///
+    /// // Updates the primitive variables at east cell faces
+    /// u.update_prim_d::<{Direction::East as u8}>();
     /// ```
-    pub fn update_prim<const D: u8>(&mut self) {
+    pub fn update_prim_d<const D: u8>(&mut self) {
         P::update_prim(self.get_vars_mut::<D>());
     }
 
-    /// Update the conservative variables
-    pub fn update_cons<const D: u8>(&mut self) {
+    /// Update the primitive variables at the cell centres
+    ///
+    /// This is a specialisation of State::update_prim_d, where the direction is set to be
+    /// Direction::Cent. The reasoning was simply that interacting with cell centre values is the
+    /// most common case, so they should have the most straight forward interface.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the primitive variables in the cell centres
+    /// u.update_prim();
+    /// ```
+    pub fn update_prim(&mut self) {
+        self.update_prim_d::<{ Direction::Cent as u8 }>();
+    }
+
+    /// Update the conservative variables at a certain part of each mesh cell
+    ///
+    /// The template parameter denotes whether to update the cell centres, west cell faces, or east
+    /// cell faces. Pass the parameter as the Direction enum cast to u8 to use this function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the conservative variables in the cell centres
+    /// u.update_cons_d::<{Direction::Cent as u8}>();
+    ///
+    /// // Updates the conservative variables at west cell faces
+    /// u.update_cons_d::<{Direction::West as u8}>();
+    ///
+    /// // Updates the conservative variables at east cell faces
+    /// u.update_cons_d::<{Direction::East as u8}>();
+    /// ```
+    pub fn update_cons_d<const D: u8>(&mut self) {
         P::update_cons(self.get_vars_mut::<D>());
     }
 
+    /// Update the conservative variables at the cell centres
+    ///
+    /// This is a specialisation of State::update_cons_d, where the direction is set to be
+    /// Direction::Cent. The reasoning was simply that interacting with cell centre values is the
+    /// most common case, so they should have the most straight forward interface.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the conservative variables in the cell centres
+    /// u.update_cons();
+    /// ```
+    pub fn update_cons(&mut self) {
+        self.update_cons_d::<{ Direction::Cent as u8 }>();
+    }
+
     /// Updates variables that are not part of the primitive or conservative variables, like speed
-    /// of sound, at the centre of the mesh's cells
-    pub fn update_derived_variables<const D: u8>(&mut self) {
+    /// of sound, at a certain part of each mesh cell
+    ///
+    /// The template parameter denotes whether to update the cell centres, west cell faces, or east
+    /// cell faces. Pass the parameter as the Direction enum cast to u8 to use this function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the derived variables in the cell centres
+    /// u.update_derived_variables_d::<{Direction::Cent as u8}>();
+    ///
+    /// // Updates the derived variables at west cell faces
+    /// u.update_derived_variables_d::<{Direction::West as u8}>();
+    ///
+    /// // Updates the derived variables at east cell faces
+    /// u.update_derived_variables_d::<{Direction::East as u8}>();
+    /// ```
+    pub fn update_derived_variables_d<const D: u8>(&mut self) {
         P::update_derived_variables(self.get_vars_mut::<D>());
     }
 
-    /// Updates the speed of the sound at the centre of the mesh's cells
-    pub fn update_c_sound<const D: u8>(&mut self) {
+    /// Updates variables that are not part of the primitive or conservative variables, like speed
+    /// of sound, at cell centres
+    ///
+    /// This is a specialisation of State::update_derived_variables_d, where the direction is set to be
+    /// Direction::Cent. The reasoning was simply that interacting with cell centre values is the
+    /// most common case, so they should have the most straight forward interface.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the derived variables in the cell centres
+    /// u.update_derived_variables();
+    /// ```
+    pub fn update_derived_variables(&mut self) {
+        self.update_derived_variables_d::<{ Direction::Cent as u8 }>();
+    }
+
+    /// Updates the speed of the sound at certain parts of each mesh cell
+    ///
+    /// The template parameter denotes whether to update the cell centres, west cell faces, or east
+    /// cell faces. Pass the parameter as the Direction enum cast to u8 to use this function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the speed of sound in the cell centres
+    /// u.update_c_sound_d::<{Direction::Cent as u8}>();
+    ///
+    /// // Updates the speed of sound at west cell faces
+    /// u.update_c_sound_d::<{Direction::West as u8}>();
+    ///
+    /// // Updates the speed of sound at east cell faces
+    /// u.update_c_sound_d::<{Direction::East as u8}>();
+    /// ```
+    pub fn update_c_sound_d<const D: u8>(&mut self) {
         P::update_c_sound(self.get_vars_mut::<D>());
     }
 
-    /// Updates the eigen values at the centre of the mesh's cells
-    pub fn update_eigen_vals<const D: u8>(&mut self) {
+    /// Updates the speed of the sound at the cell centres
+    ///
+    /// This is a specialisation of State::update_c_sound_d, where the direction is set to be
+    /// Direction::Cent. The reasoning was simply that interacting with cell centre values is the
+    /// most common case, so they should have the most straight forward interface.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the speed of sound in the cell centres
+    /// u.update_c_sound();
+    /// ```
+    pub fn update_c_sound(&mut self) {
+        self.update_c_sound_d::<{ Direction::Cent as u8 }>();
+    }
+
+    /// Updates the eigen values at certain parts of each mesh cell
+    ///
+    /// The template parameter denotes whether to update the cell centres, west cell faces, or east
+    /// cell faces. Pass the parameter as the Direction enum cast to u8 to use this function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the eigen values in the cell centres
+    /// u.update_eigen_vals_d::<{Direction::Cent as u8}>();
+    ///
+    /// // Updates the eigen values at west cell faces
+    /// u.update_eigen_vals_d::<{Direction::West as u8}>();
+    ///
+    /// // Updates the eigen values at east cell faces
+    /// u.update_eigen_vals_d::<{Direction::East as u8}>();
+    /// ```
+    pub fn update_eigen_vals_d<const D: u8>(&mut self) {
         P::update_eigen_vals(self.get_vars_mut::<D>());
     }
 
-    /// Updates the minimal eigen values at the centre of the mesh's cells
-    pub fn update_eigen_vals_min<const D: u8>(&mut self) {
+    /// Updates the eigen values at cell centres
+    ///
+    /// This is a specialisation of State::update_eigen_vals_d, where the direction is set to be
+    /// Direction::Cent. The reasoning was simply that interacting with cell centre values is the
+    /// most common case, so they should have the most straight forward interface.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the eigen values in the cell centres
+    /// u.update_eigen_vals();
+    /// ```
+    pub fn update_eigen_vals(&mut self) {
+        self.update_eigen_vals_d::<{ Direction::Cent as u8 }>();
+    }
+
+    /// Updates the minimal eigen values at certain parts of each mesh cell
+    ///
+    /// The template parameter denotes whether to update the cell centres, west cell faces, or east
+    /// cell faces. Pass the parameter as the Direction enum cast to u8 to use this function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the minimal eigen values in the cell centres
+    /// u.update_eigen_vals_min_d::<{Direction::Cent as u8}>();
+    ///
+    /// // Updates the minimal eigen values at west cell faces
+    /// u.update_eigen_vals_min_d::<{Direction::West as u8}>();
+    ///
+    /// // Updates the minimal eigen values at east cell faces
+    /// u.update_eigen_vals_min_d::<{Direction::East as u8}>();
+    /// ```
+    pub fn update_eigen_vals_min_d<const D: u8>(&mut self) {
         P::update_eigen_vals_min(self.get_vars_mut::<D>());
     }
 
-    /// Updates the maximal eigen values at the centre of the mesh's cells
-    pub fn update_eigen_vals_max<const D: u8>(&mut self) {
+    /// Updates the minimal eigen values at cell centres
+    ///
+    /// This is a specialisation of State::update_eigen_vals_min_d, where the direction is set to be
+    /// Direction::Cent. The reasoning was simply that interacting with cell centre values is the
+    /// most common case, so they should have the most straight forward interface.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the minimal eigen values in the cell centres
+    /// u.update_eigen_vals_min();
+    /// ```
+    pub fn update_eigen_vals_min(&mut self) {
+        self.update_eigen_vals_min_d::<{ Direction::Cent as u8 }>();
+    }
+
+    /// Updates the maximal eigen values at certain parts of each mesh cell
+    ///
+    /// The template parameter denotes whether to update the cell centres, west cell faces, or east
+    /// cell faces. Pass the parameter as the Direction enum cast to u8 to use this function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the maximal eigen values in the cell centres
+    /// u.update_eigen_vals_max_d::<{Direction::Cent as u8}>();
+    ///
+    /// // Updates the maximal eigen values at west cell faces
+    /// u.update_eigen_vals_max_d::<{Direction::West as u8}>();
+    ///
+    /// // Updates the maximal eigen values at east cell faces
+    /// u.update_eigen_vals_max_d::<{Direction::East as u8}>();
+    /// ```
+    pub fn update_eigen_vals_max_d<const D: u8>(&mut self) {
         P::update_eigen_vals_max(self.get_vars_mut::<D>());
     }
 
-    /// Updates the physical flux at the centre of the mesh's cells
-    pub fn update_flux<const D: u8>(&mut self) {
+    /// Updates the maximal eigen values at cell centres
+    ///
+    /// This is a specialisation of State::update_eigen_vals_max_d, where the direction is set to be
+    /// Direction::Cent. The reasoning was simply that interacting with cell centre values is the
+    /// most common case, so they should have the most straight forward interface.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the maximal eigen values in the cell centres
+    /// u.update_eigen_vals_max();
+    /// ```
+    pub fn update_eigen_vals_max(&mut self) {
+        self.update_eigen_vals_max_d::<{ Direction::Cent as u8 }>();
+    }
+
+    /// Updates the physical flux at certain parts of each mesh cell
+    ///
+    /// The template parameter denotes whether to update the cell centres, west cell faces, or east
+    /// cell faces. Pass the parameter as the Direction enum cast to u8 to use this function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the physical flux in the cell centres
+    /// u.update_flux_d::<{Direction::Cent as u8}>();
+    ///
+    /// // Updates the physical flux at west cell faces
+    /// u.update_flux_d::<{Direction::West as u8}>();
+    ///
+    /// // Updates the physical flux at east cell faces
+    /// u.update_flux_d::<{Direction::East as u8}>();
+    /// ```
+    pub fn update_flux_d<const D: u8>(&mut self) {
         P::update_flux(self.get_vars_mut::<D>());
     }
 
-    /// Update the full .cent field, assuming that .cent.prim is already up-to-date
-    pub fn update_cent_from_prim(
-        &mut self,
-        boundary_west: &mut Box<dyn BoundaryCondition<E, S>>,
-        boundary_east: &mut Box<dyn BoundaryCondition<E, S>>,
-        mesh: &Mesh<S>,
-    ) {
-        P::update_vars_from_prim(&mut self.cent, boundary_west, boundary_east, mesh);
+    /// Updates the physical flux at cell centres
+    ///
+    /// This is a specialisation of State::update_flux_d, where the direction is set to be
+    /// Direction::Cent. The reasoning was simply that interacting with cell centre values is the
+    /// most common case, so they should have the most straight forward interface.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// // Updates the physical flux in the cell centres
+    /// u.update_flux();
+    /// ```
+    pub fn update_flux(&mut self) {
+        self.update_flux_d::<{ Direction::Cent as u8 }>();
     }
 
-    /// Update the full .west field, assuming that .west.prim is already up-to-date
-    pub fn update_west_from_prim(
+    /// Updates all variables at certain parts of each mesh cell, assuming that primitive variables
+    /// are up to date
+    ///
+    /// The template parameter denotes whether to update the cell centres, west cell faces, or east
+    /// cell faces. Pass the parameter as the Direction enum cast to u8 to use this function.
+    pub fn update_vars_from_prim_d<const D: u8>(
         &mut self,
         boundary_west: &mut Box<dyn BoundaryCondition<E, S>>,
         boundary_east: &mut Box<dyn BoundaryCondition<E, S>>,
         mesh: &Mesh<S>,
     ) {
-        P::update_vars_from_prim(&mut self.west, boundary_west, boundary_east, mesh);
+        P::update_vars_from_prim(self.get_vars_mut::<D>(), boundary_west, boundary_east, mesh);
     }
 
-    /// Update the full .east field, assuming that .east.prim is already up-to-date
-    pub fn update_east_from_prim(
+    /// Updates all variables at cell centres, assuming that primitive variables are up to date
+    ///
+    /// This is a specialisation of State::update_vars_from_prim_d, where the direction is set to be
+    /// Direction::Cent. The reasoning was simply that interacting with cell centre values is the
+    /// most common case, so they should have the most straight forward interface.
+    pub fn update_vars_from_prim(
         &mut self,
         boundary_west: &mut Box<dyn BoundaryCondition<E, S>>,
         boundary_east: &mut Box<dyn BoundaryCondition<E, S>>,
         mesh: &Mesh<S>,
     ) {
-        P::update_vars_from_prim(&mut self.east, boundary_west, boundary_east, mesh);
+        self.update_vars_from_prim_d::<{ Direction::Cent as u8 }>(boundary_west, boundary_east, mesh);
     }
 
-    /// Update the full .cent field, assuming that .cent.cons is already up-to-date
-    pub fn update_cent_from_cons(
+    /// Updates all variables at certain parts of each mesh cell, assuming that conservative variables
+    /// are up to date
+    ///
+    /// The template parameter denotes whether to update the cell centres, west cell faces, or east
+    /// cell faces. Pass the parameter as the Direction enum cast to u8 to use this function.
+    pub fn update_vars_from_cons_d<const D: u8>(
         &mut self,
         boundary_west: &mut Box<dyn BoundaryCondition<E, S>>,
         boundary_east: &mut Box<dyn BoundaryCondition<E, S>>,
         mesh: &Mesh<S>,
     ) {
-        P::update_vars_from_cons(&mut self.cent, boundary_west, boundary_east, mesh);
+        P::update_vars_from_cons(self.get_vars_mut::<D>(), boundary_west, boundary_east, mesh);
     }
 
-    /// Update the full .west field, assuming that .west.cons is already up-to-date
-    pub fn update_west_from_cons(
+    /// Updates all variables at cell centres, assuming that conservative variables are up to date
+    ///
+    /// This is a specialisation of State::update_vars_from_cons_d, where the direction is set to be
+    /// Direction::Cent. The reasoning was simply that interacting with cell centre values is the
+    /// most common case, so they should have the most straight forward interface.
+    pub fn update_vars_from_cons(
         &mut self,
         boundary_west: &mut Box<dyn BoundaryCondition<E, S>>,
         boundary_east: &mut Box<dyn BoundaryCondition<E, S>>,
         mesh: &Mesh<S>,
     ) {
-        P::update_vars_from_cons(&mut self.west, boundary_west, boundary_east, mesh);
-    }
-
-    /// Update the full .east field, assuming that .east.cons is already up-to-date
-    pub fn update_east_from_cons(
-        &mut self,
-        boundary_west: &mut Box<dyn BoundaryCondition<E, S>>,
-        boundary_east: &mut Box<dyn BoundaryCondition<E, S>>,
-        mesh: &Mesh<S>,
-    ) {
-        P::update_vars_from_cons(&mut self.east, boundary_west, boundary_east, mesh);
+        self.update_vars_from_cons_d::<{ Direction::Cent as u8 }>(boundary_west, boundary_east, mesh);
     }
 
     /// Assigns the fields of rhs to self
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u1: State<P, E, S> = State::new(&physics_config);
+    /// let mut u2: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// u1.cent.prim[[0,0]] = 0.0;
+    /// u2.cent.prim[[0,0]] = 1.0;
+    ///
+    /// u1.west.prim[[0,0]] = 0.0;
+    /// u2.west.prim[[0,0]] = 2.0;
+    ///
+    /// u1.east.prim[[0,0]] = 0.0;
+    /// u2.east.prim[[0,0]] = 3.0;
+    ///
+    /// // Updates all fields of u2 to u1
+    /// u1.assign(&u2);
+    ///
+    /// assert_eq!(u1.cent.prim[[0,0]], 1.0);
+    /// assert_eq!(u1.west.prim[[0,0]], 2.0);
+    /// assert_eq!(u1.east.prim[[0,0]], 3.0);
+    /// ```
     pub fn assign(&mut self, rhs: &Self) {
-        self.assign_cent(rhs);
-        self.west.assign(&rhs.west);
-        self.east.assign(&rhs.east);
+        self.assign_vars_d::<{ Direction::Cent as u8 }>(rhs);
+        self.assign_vars_d::<{ Direction::West as u8 }>(rhs);
+        self.assign_vars_d::<{ Direction::East as u8 }>(rhs);
     }
 
-    /// Assigns rhs.cent to self.cent
-    pub fn assign_cent(&mut self, rhs: &Self) {
-        self.cent.assign(&rhs.cent);
+    /// Assigns rhs to self at certain parts of each mesh cell
+    ///
+    /// The template parameter denotes whether to update the cell centres, west cell faces, or east
+    /// cell faces. Pass the parameter as the Direction enum cast to u8 to use this function.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u1: State<P, E, S> = State::new(&physics_config);
+    /// let mut u2: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// u1.cent.prim[[0,0]] = 0.0;
+    /// u2.cent.prim[[0,0]] = 1.0;
+    ///
+    /// u1.west.prim[[0,0]] = 0.0;
+    /// u2.west.prim[[0,0]] = 2.0;
+    ///
+    /// u1.east.prim[[0,0]] = 0.0;
+    /// u2.east.prim[[0,0]] = 3.0;
+    ///
+    /// // Assigns vars from u2 to u1 in the cell centres
+    /// u1.assign_vars_d::<{Direction::Cent as u8}>(&u2);
+    ///
+    /// // Assigns vars from u2 to u1 at west cell faces
+    /// u1.assign_vars_d::<{Direction::West as u8}>(&u2);
+    ///
+    /// // Assigns vars from u2 to u1 at east cell faces
+    /// u1.assign_vars_d::<{Direction::East as u8}>(&u2);
+    ///
+    /// assert_eq!(u1.cent.prim[[0,0]], 1.0);
+    /// assert_eq!(u1.west.prim[[0,0]], 2.0);
+    /// assert_eq!(u1.east.prim[[0,0]], 3.0);
+    /// ```
+    pub fn assign_vars_d<const D: u8>(&mut self, rhs: &Self) {
+        self.get_vars_mut::<D>().assign(&rhs.get_vars::<D>());
+    }
+
+    /// Assigns the fields of rhs to self for cell centric values
+    ///
+    /// This is a specialisation of State::assign_vars_d, where the direction is set to be
+    /// Direction::Cent. The reasoning was simply that interacting with cell centre values is the
+    /// most common case, so they should have the most straight forward interface.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use corries::prelude::*;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// const S: usize = 10;
+    /// let physics_config = PhysicsConfig { adiabatic_index: 1.66, units_mode: UnitsMode::SI };
+    /// let mut u1: State<P, E, S> = State::new(&physics_config);
+    /// let mut u2: State<P, E, S> = State::new(&physics_config);
+    ///
+    /// u1.cent.prim[[0,0]] = 0.0;
+    /// u2.cent.prim[[0,0]] = 1.0;
+    ///
+    /// // Updates all fields of u2 to u1
+    /// u1.assign_vars(&u2);
+    ///
+    /// assert_eq!(u1.cent.prim[[0,0]], 1.0);
+    /// ```
+    pub fn assign_vars(&mut self, rhs: &Self) {
+        self.assign_vars_d::<{ Direction::Cent as u8 }>(rhs);
     }
 
     /// Calculates the time step width according to the CFL criterium
@@ -257,8 +674,8 @@ mod tests {
                 u.cent.prim.row_mut(0).fill(p0);
                 u.cent.prim.row_mut(1).fill(p1);
                 u.cent.prim.row_mut(2).fill(p2);
-                u.update_cons_cent();
-                u.update_prim_cent();
+                u.update_cons();
+                u.update_prim();
                 assert_relative_eq!(u.cent.prim.row(0), u0.cent.prim.row(0), max_relative = 1.0e-12);
                 assert_relative_eq!(u.cent.prim.row(1), u0.cent.prim.row(1), max_relative = 1.0e-12);
                 assert_relative_eq!(u.cent.prim.row(2), u0.cent.prim.row(2), max_relative = 1.0e-8);
@@ -279,8 +696,8 @@ mod tests {
                 let mut u = State::<P, E, S>::new(&PHYSICS_CONFIG);
                 u.cent.prim.row_mut(0).fill(p0);
                 u.cent.prim.row_mut(1).fill(p1);
-                u.update_cons_cent();
-                u.update_prim_cent();
+                u.update_cons();
+                u.update_prim();
                 assert_relative_eq!(u.cent.prim, u0.cent.prim, max_relative = 1.0e-12);
             }
         }

--- a/src/time/rkf.rs
+++ b/src/time/rkf.rs
@@ -133,7 +133,7 @@ impl<P: Physics<E, S> + 'static, const E: usize, const S: usize> TimeSolver<P, E
             .context("RungeKuttaFehlberg::calc_rkf_solution at the end of RungeKuttaFehlberg::next_solution")?;
 
         u.cent.cons.assign(&self.utilde.cent.cons);
-        u.update_cent_from_cons(&mut rhs.boundary_west, &mut rhs.boundary_east, mesh);
+        u.update_vars_from_cons(&mut rhs.boundary_west, &mut rhs.boundary_east, mesh);
         if cfg!(feature = "validation") {
             u.validate()
                 .context("Calling u.update_everything_from_prim at the end of RungeKuttaFehlberg::calc_rkf_solution")?;

--- a/tests/noh.rs
+++ b/tests/noh.rs
@@ -164,7 +164,7 @@ fn noh_euler1d_adiabatic() -> Result<()> {
     let mut writer = Writer::new::<S>(&config, &mesh)?;
 
     init_noh::<P, E, S>(&mut u);
-    u.update_cent_from_prim(&mut rhs.boundary_west, &mut rhs.boundary_east, &mesh);
+    u.update_vars_from_prim(&mut rhs.boundary_west, &mut rhs.boundary_east, &mesh);
 
     run_corries::<P, N, T, E, S>(&mut u, &mut rhs, &mut time, &mesh, &mut writer)
         .context("Calling run_loop in noh test")?;
@@ -185,7 +185,7 @@ fn noh_euler1d_isot() -> Result<()> {
     let mut writer = Writer::new::<S>(&config, &mesh)?;
 
     init_noh::<P, E, S>(&mut u);
-    u.update_cent_from_prim(&mut rhs.boundary_west, &mut rhs.boundary_east, &mesh);
+    u.update_vars_from_prim(&mut rhs.boundary_west, &mut rhs.boundary_east, &mesh);
 
     run_corries::<P, N, T, E, S>(&mut u, &mut rhs, &mut time, &mesh, &mut writer)
         .context("Calling run_loop in noh test")?;

--- a/tests/sod.rs
+++ b/tests/sod.rs
@@ -123,7 +123,7 @@ fn sod_hll() -> Result<()> {
     let mut writer = Writer::new::<S>(&config, &mesh)?;
 
     init::<P, E, S>(&mut u);
-    u.update_cent_from_prim(&mut rhs.boundary_west, &mut rhs.boundary_east, &mesh);
+    u.update_vars_from_prim(&mut rhs.boundary_west, &mut rhs.boundary_east, &mesh);
 
     run_corries::<P, N, T, E, S>(&mut u, &mut rhs, &mut time, &mesh, &mut writer)
         .context("Calling run_loop in noh test")?;
@@ -146,7 +146,7 @@ fn sod_kt() -> Result<()> {
     let mut writer = Writer::new::<S>(&config, &mesh)?;
 
     init::<P, E, S>(&mut u);
-    u.update_cent_from_prim(&mut rhs.boundary_west, &mut rhs.boundary_east, &mesh);
+    u.update_vars_from_prim(&mut rhs.boundary_west, &mut rhs.boundary_east, &mesh);
     u.init_west_east();
 
     run_corries::<P, N, T, E, S>(&mut u, &mut rhs, &mut time, &mesh, &mut writer)


### PR DESCRIPTION
This PR adds the `Directions` enum, which enumerates the different parts of mesh cell. This is used by the `State` struct to generalise a bunch of methods, making them generic over a constant generic parameter to denote which set of variables is affected.

NOTE: This PR dramatically changes the surface of `State`!