### PR TITLE
Streamline init

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -85,7 +85,7 @@ where
                 break;
             }
 
-            if let err @ Err(_) = solver.next_solution(u, &mesh) {
+            if let err @ Err(_) = solver.next_solution(u, mesh) {
                 solver.timestep.dt_kind = DtKind::ErrorDump;
                 writer
                     .update_data(&u.cent, &solver.timestep, mesh)

--- a/src/components.rs
+++ b/src/components.rs
@@ -4,8 +4,8 @@
 
 //! Exports the [CorriesComponents] type alias, as well as [Runner] trait.
 
-use color_eyre::{eyre::Context, Result};
 use crate::{DtKind, Mesh, NumFlux, Physics, Solver, State, TimeSolver, Writer};
+use color_eyre::{eyre::Context, Result};
 
 /// This trait is written solely for the purpose of implementing this method on CorriesComponents,
 /// which itself is just a type alias.

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2023
+// Author: Tommy Breslein (github.com/tbreslein)
+// License: MIT
+
+//! TODO
+
+use color_eyre::{eyre::Context, Result};
+
+use crate::{DtKind, Mesh, NumFlux, Physics, Solver, State, TimeSolver, Writer};
+
+/// todo
+pub trait Runner {
+    /// todo
+    fn run_corries(&mut self) -> Result<()>;
+}
+
+/// todo
+pub type CorriesComponents<P, N, T, const E: usize, const S: usize> =
+    (State<P, E, S>, Solver<P, N, T, E, S>, Mesh<S>, Writer);
+
+impl<P, N, T, const E: usize, const S: usize> Runner for CorriesComponents<P, N, T, E, S>
+where
+    P: Physics<E, S>,
+    N: NumFlux<E, S>,
+    T: TimeSolver<P, E, S>,
+{
+    fn run_corries(&mut self) -> Result<()> {
+        // source: https://stackoverflow.com/questions/41207306/mutable-reference-to-a-tuple-as-input-parameter
+        // This is where I learned what the ref keyword is...
+        let (ref mut u, ref mut solver, ref mesh, ref mut writer) = *self;
+        loop {
+            if solver.timestep.t >= solver.timestep.t_next_output - solver.timestep.dt_min {
+                solver.timestep.t_next_output += solver.timestep.dt_output;
+                writer
+                    .update_data(&u.cent, &solver.timestep, mesh)
+                    .context("Calling writer.update_data_matrices in run_corries")?;
+                writer
+                    .write_output()
+                    .context("Calling wirter.write_output in run_corries")?;
+            }
+
+            if solver.timestep.t + solver.timestep.dt_min * 0.01 >= solver.timestep.t_end {
+                break;
+            }
+
+            if let err @ Err(_) = solver.next_solution(u, &mesh) {
+                solver.timestep.dt_kind = DtKind::ErrorDump;
+                writer
+                    .update_data(&u.cent, &solver.timestep, mesh)
+                    .context("Calling writer.update_data_matrices during the error dump in run_corries")?;
+                writer
+                    .write_output()
+                    .context("Calling writer.write_output during the error dump in run_corries")?;
+                return err;
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/components.rs
+++ b/src/components.rs
@@ -2,19 +2,32 @@
 // Author: Tommy Breslein (github.com/tbreslein)
 // License: MIT
 
-//! TODO
+//! Exports the [CorriesComponents] type alias, as well as [Runner] trait.
 
 use color_eyre::{eyre::Context, Result};
-
 use crate::{DtKind, Mesh, NumFlux, Physics, Solver, State, TimeSolver, Writer};
 
-/// todo
+/// This trait is written solely for the purpose of implementing this method on CorriesComponents,
+/// which itself is just a type alias.
+///
+/// Refer to [CorriesComponents] for a detailed usage example.
 pub trait Runner {
-    /// todo
+    /// Runs a [corries](crate) simulation.
+    ///
+    /// Refer to [CorriesComponents] for a detailed usage example.
     fn run_corries(&mut self) -> Result<()>;
 }
 
-/// todo
+/// A type alias around a tuple of the four components of a [corries](crate) simulation:
+///
+/// * [State]
+/// * [Solver]
+/// * [Mesh]
+/// * [Writer]
+///
+/// The main purpose of this tuple is to be a return type for
+/// [CorriesConfig::init_corries()](crate::CorriesConfig::init_corries()). With that, we can chain
+/// that method into the [Runner::run_corries()] method to run the simulation.
 pub type CorriesComponents<P, N, T, const E: usize, const S: usize> =
     (State<P, E, S>, Solver<P, N, T, E, S>, Mesh<S>, Writer);
 
@@ -24,6 +37,35 @@ where
     N: NumFlux<E, S>,
     T: TimeSolver<P, E, S>,
 {
+    /// Runs a [corries](crate) simulation.
+    ///
+    /// This assumes that you already set your initial conditions in `u` and that it is fully
+    /// up-to-date.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use corries::prelude::*;
+    ///
+    /// // Set up a simulation using isothermal Euler physics on a 100 cell mesh, using the Hll and
+    /// // Runge-Kutta-Fehlberg schemes for solving the equations.
+    /// const S: usize = 100;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// type N = Hll<E, S>;
+    /// type T = RungeKuttaFehlberg<P, E, S>;
+    ///
+    /// // use the default config for Riemann tests
+    /// let t_end = 0.5;
+    /// let folder_name = "results";
+    /// let file_name = "noh";
+    ///
+    /// // define the config instance
+    /// CorriesConfig::default_riemann_test::<N, E, S>(t_end, folder_name, file_name)
+    ///     .init_corries::<P, N, T, E,S>(|_, _, _| Ok(()))
+    ///     .unwrap()
+    ///     .run_corries()
+    ///     .unwrap()
+    /// ```
     fn run_corries(&mut self) -> Result<()> {
         // source: https://stackoverflow.com/questions/41207306/mutable-reference-to-a-tuple-as-input-parameter
         // This is where I learned what the ref keyword is...

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,7 +202,7 @@ impl CorriesConfig {
     /// ```
     pub fn init_corries<P, N, T, const E: usize, const S: usize>(
         &self,
-        init_fn: fn(&mut State<P,E,S>, &mut Solver<P,N,T,E,S>, &Mesh<S>) -> Result<()>,
+        init_fn: fn(&mut State<P, E, S>, &mut Solver<P, N, T, E, S>, &Mesh<S>) -> Result<()>,
     ) -> Result<CorriesComponents<P, N, T, E, S>>
     where
         P: Physics<E, S> + 'static,

--- a/src/config.rs
+++ b/src/config.rs
@@ -200,6 +200,7 @@ impl CorriesConfig {
     ///         Ok(())
     ///     }).unwrap();
     /// ```
+    #[allow(clippy::type_complexity)]
     pub fn init_corries<P, N, T, const E: usize, const S: usize>(
         &self,
         init_fn: fn(&mut State<P, E, S>, &mut Solver<P, N, T, E, S>, &Mesh<S>) -> Result<()>,
@@ -213,8 +214,8 @@ impl CorriesConfig {
 
         let mesh = Mesh::<S>::new(&self.mesh_config).context("Constructing Mesh")?;
         let mut u = State::<P, E, S>::new(&self.physics_config);
-        let mut solver = Solver::<P, N, T, E, S>::new(&self, &mesh).context("Constructing Solver")?;
-        let mut writer = Writer::new::<S>(&self, &mesh).context("Constructing Writer")?;
+        let mut solver = Solver::<P, N, T, E, S>::new(self, &mesh).context("Constructing Solver")?;
+        let mut writer = Writer::new::<S>(self, &mesh).context("Constructing Writer")?;
 
         if writer.print_banner {
             println!("# ****************************************");

--- a/src/config.rs
+++ b/src/config.rs
@@ -162,7 +162,44 @@ impl CorriesConfig {
         }
     }
 
-    /// todo
+    /// Initialises all objects needed to run a corries simulation.
+    ///
+    /// Apart from the `self` argument, the important bits that also help configuring the simulation
+    /// are the template Parameters. For example, the type you pass as the first template argument
+    /// determines the type of [Physics] used throughout the whole simulation!
+    ///
+    /// In addition to that, you also need to pass a function that takes a [State], a [Solver], and
+    /// a [Mesh], and returns a [color_eyre::Result].
+    /// That function is used to apply the initial conditions to the [State] object.
+    ///
+    /// In that `init_fn` you only need to concern yourself with setting initial values for the
+    /// [State::cent.prim] field for the [State] object.
+    /// After calling `init_fn`, this `init_corries` method will make sure that [State::west] and
+    /// [State::east] are initialised, as well as that the boundary conditions are applied.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use corries::prelude::*;
+    ///
+    /// // Set up a simulation using isothermal Euler physics on a 100 cell mesh, using the Hll and
+    /// // Runge-Kutta-Fehlberg schemes for solving the equations.
+    /// const S: usize = 100;
+    /// set_Physics_and_E!(Euler1DIsot);
+    /// type N = Hll<E, S>;
+    /// type T = RungeKuttaFehlberg<P, E, S>;
+    ///
+    /// // use the default config for Riemann tests
+    /// let t_end = 0.5;
+    /// let folder_name = "results";
+    /// let file_name = "noh";
+    ///
+    /// CorriesConfig::default_riemann_test::<N, E, S>(t_end, folder_name, file_name)
+    ///     .init_corries::<P, N, T, E, S>(|u, solver, mesh| {
+    ///         /* ... some complex initial conditions for u ... */
+    ///         Ok(())
+    ///     }).unwrap();
+    /// ```
     pub fn init_corries<P, N, T, const E: usize, const S: usize>(
         &self,
         init_fn: fn(&mut State<P,E,S>, &mut Solver<P,N,T,E,S>, &Mesh<S>) -> Result<()>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //! * Building a [CorriesConfig], which allows for fine-grained control over the simulation
 //! * Constructing and applying initial conditions to the necessary objects through the
 //! [CorriesConfig::init_corries]
-//! * Running the simulation with the [CorriesComponents]'s [run_corries] method
+//! * Running the simulation with the [CorriesComponents]'s [Runner::run_corries] method
 //!
 //! You can see examples of this in the docs for [CorriesConfig::init_corries] and
 //! [Runner::run_corries], as well as when looking through the source code for the integration
@@ -456,7 +456,7 @@
 //! * `writer`: the [Writer] object that handles writing output
 //!
 //! Almost done.
-//! Now we can call [run_corries] to run the simulation!
+//! Now we can call [Runner::run_corries] to run the simulation!
 //!
 //! ```no_run
 //! # use color_eyre::{eyre::Context, Result};
@@ -516,15 +516,6 @@
 //! Currently, corries only supports cartesian meshes, though non-cartesian meshes are coming very
 //! soon.
 //!
-//! * streamline initial conditions a bit
-//!   * make [init_corries] a method of [CorriesConfig]
-//!   * that method calls the original [init_corries] logic first, then it calls a user provided
-//!   function which applies initial conditions
-//!   * after calling the user provided function, the method automatically makes sure that all
-//!   variables as well as `u.west` und `u.east` are set up properly
-//!   * the method returns the tuple of `(u, solver, mesh, writer)` which are bundled into the
-//!   `CorriesComponents` typedef
-//!    add a method `run` to that type that is basically just calling [run_corries]
 //! * Add cylindrical geometry + Source trait + GeometricSource + Sedov test
 //! * Add spherical geometry + new Sedov case
 //! * Add Euler2DAdiabatic
@@ -555,16 +546,18 @@ pub mod writer;
 
 /// Exports everything you need to run a corries simulation. This includes the following modules
 ///
-/// - [corries::config](crate::config)
-/// - [corries::directions](crate::directions)
-/// - [corries::mesh](crate::mesh)
-/// - [corries::physics](crate::physics)
-/// - [corries::rhs](crate::rhs)
-/// - [corries::time](crate::time)
-/// - [corries::units](crate::units)
-/// - [corries::writer](crate::writer)
+/// * [corries::components](crate::components)
+/// * [corries::config](crate::config)
+/// * [corries::directions](crate::directions)
+/// * [corries::mesh](crate::mesh)
+/// * [corries::rhs](crate::rhs)
+/// * [corries::solver](crate::solver)
+/// * [corries::state](crate::state)
+/// * [corries::time](crate::time)
+/// * [corries::units](crate::units)
+/// * [corries::writer](crate::writer)
 ///
-/// as well as the [set_Physics_and_E] macro, and the [run_corries], and [init_corries] function.
+/// as well as the [set_Physics_and_E] macro
 pub mod prelude {
     pub use crate::components::*;
     pub use crate::config::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,6 +553,7 @@
 //! Most importantly exports the module [prelude].
 
 mod boundaryconditions;
+pub mod components;
 pub mod config;
 mod errorhandling;
 #[macro_use]
@@ -579,6 +580,7 @@ pub mod writer;
 ///
 /// as well as the [set_Physics_and_E] macro, and the [run_corries], and [init_corries] function.
 pub mod prelude {
+    pub use crate::components::*;
     pub use crate::config::*;
     pub use crate::directions::*;
     pub use crate::init_corries;
@@ -594,11 +596,9 @@ pub mod prelude {
 }
 
 use color_eyre::{eyre::Context, Result};
+use components::CorriesComponents;
 use errorhandling::Validation;
 pub use prelude::*;
-
-type CorriesComponents<P, N, T, const E: usize, const S: usize> =
-    (State<P, E, S>, Solver<P, N, T, E, S>, Mesh<S>, Writer);
 
 /// Initialises all objects needed to run a corries simulation.
 ///
@@ -649,9 +649,9 @@ where
     let solver = Solver::<P, N, T, E, S>::new(config, &mesh)?;
     let mut writer = Writer::new::<S>(config, &mesh)?;
 
-    if writer.print_banner {
-        print_banner();
-    }
+    // if writer.print_banner {
+    //     print_banner();
+    // }
     writer
         .write_metadata::<S>()
         .context("Calling writer.write_metadata in run_corries")?;
@@ -729,16 +729,4 @@ pub fn run_corries<P: Physics<E, S>, N: NumFlux<E, S>, T: TimeSolver<P, E, S>, c
         }
     }
     Ok(())
-}
-
-const VERSION: &str = env!("CARGO_PKG_VERSION");
-fn print_banner() {
-    println!("# ****************************************");
-    println!("# Corries - corrosive Riemann solver ");
-    println!("# ");
-    println!("# Version: {VERSION}");
-    println!("# Copyright (c) 2022-2023");
-    println!("# Author: tbreslein <github.com/tbreslein>");
-    println!("# License: MIT");
-    println!("# ****************************************");
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -91,7 +91,7 @@ impl<P: Physics<E, S>, N: NumFlux<E, S>, T: TimeSolver<P, E, S>, const E: usize,
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use corries::prelude::*;
     ///
     /// // Set up a simulation using isothermal Euler physics on a 100 cell mesh, using the Hll and
@@ -108,8 +108,9 @@ impl<P: Physics<E, S>, N: NumFlux<E, S>, T: TimeSolver<P, E, S>, const E: usize,
     ///
     /// // define the config instance
     /// let config = CorriesConfig::default_riemann_test::<N, E, S>(t_end, folder_name, file_name);
-    /// let (mut u, mut solver, mesh, _) = init_corries::<P, N, T, E, S>(&config).unwrap();
-    /// solver.next_solution(&mut u, &mesh);
+    /// let (mut u, mut solver, mesh, _) = config.init_corries::<P, N, T, E, S>(|_,_,_| Ok(())).unwrap();
+    ///
+    /// solver.next_solution(&mut u, &mesh).unwrap();
     /// ```
     pub fn next_solution(&mut self, u: &mut State<P, E, S>, mesh: &Mesh<S>) -> Result<()> {
         self.time_solver

--- a/src/time.rs
+++ b/src/time.rs
@@ -98,10 +98,9 @@ pub trait TimeSolver<P: Physics<E, S>, const E: usize, const S: usize> {
     /// let folder_name = "results";
     /// let file_name = "noh";
     ///
-    /// // define the config instance
     /// let config = CorriesConfig::default_riemann_test::<N, E, S>(t_end, folder_name, file_name);
+    /// let (mut u, mut solver, mesh, _) = config.init_corries::<P, N, T, E, S>(|_,_,_| Ok(())).unwrap();
     ///
-    /// let (mut u, mut solver, mesh, _) = init_corries::<P, N, T, E, S>(&config).unwrap();
     /// // solver carries the an instance of [TimeSolver]
     /// solver.next_solution(&mut u, &mesh).unwrap();
     /// ```

--- a/src/time/timestep.rs
+++ b/src/time/timestep.rs
@@ -124,7 +124,7 @@ impl TimeStep {
     ///
     /// // define the config instance
     /// let config = CorriesConfig::default_riemann_test::<N, E, S>(t_end, folder_name, file_name);
-    /// let (mut u, mut solver, mesh, _) = init_corries::<P, N, T, E, S>(&config).unwrap();
+    /// let (mut u, mut solver, mesh, _) = config.init_corries::<P, N, T, E, S>(|_,_,_| Ok(())).unwrap();
     /// solver.timestep.calc_dt_expl(&mut u, &mesh).unwrap();
     /// ```
     pub fn calc_dt_expl<P: Physics<E, S>, const E: usize, const S: usize>(

--- a/tests/sod.rs
+++ b/tests/sod.rs
@@ -55,9 +55,9 @@ fn sod_hll() -> Result<()> {
     type T = RungeKuttaFehlberg<P, E, S>;
 
     get_config::<N, E>("results/integrationtests/sod_hll", "sod_hll")
-    .init_corries::<P, N, T, E, S>(init)
-    .context("While calling CorriesConfig::init_corries")?
-    .run_corries()
+        .init_corries::<P, N, T, E, S>(init)
+        .context("While calling CorriesConfig::init_corries")?
+        .run_corries()
 }
 
 #[test]
@@ -67,7 +67,7 @@ fn sod_kt() -> Result<()> {
     type T = RungeKuttaFehlberg<P, E, S>;
 
     get_config::<N, E>("results/integrationtests/sod_kt", "sod_kt")
-    .init_corries::<P, N, T, E, S>(init)
-    .context("While calling CorriesConfig::init_corries")?
-    .run_corries()
+        .init_corries::<P, N, T, E, S>(init)
+        .context("While calling CorriesConfig::init_corries")?
+        .run_corries()
 }


### PR DESCRIPTION
The whole init process has been massively streamlined. This PR:

* adds the `init_corries` method to `CorriesConfig`, which handles the full init process
* add the `run_corries` method to the resulting `CorriesComponents`

These two methods replace the old functions of the same name.