### PR TITLE
refactor: redo TimeIntegrationConfig

### DIFF
--- a/examples/template.rs
+++ b/examples/template.rs
@@ -39,13 +39,12 @@ fn main() -> Result<()> {
             numflux_config: NumFluxConfig::Kt {
                 limiter_mode: LimiterMode::Monocent(1.2),
             },
-            time_integration_config: TimeIntegrationConfig::Rkf(RkfConfig {
+            time_integration_config: TimeIntegrationConfig::RkfASC {
                 rkf_mode: RKFMode::RK4,
-                asc: false,
-                asc_relative_tolerance: 0.001,
-                asc_absolute_tolerance: 0.1,
-                asc_timestep_friction: 0.08,
-            }),
+                relative_tolerance: 0.001,
+                absolute_tolerance: 0.1,
+                timestep_friction: 0.08,
+            },
             iter_max: usize::MAX - 2,
             t0: 0.0,
             t_end: 10.0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,28 +191,24 @@
 //!
 //!         // Sets up the time integration scheme.
 //!         // Currently, corries only supports Runge-Kutta-Fehlberg schemes, which are set here.
-//!         time_integration_config: TimeIntegrationConfig::Rkf(RkfConfig {
+//!         time_integration_config: TimeIntegrationConfig::RkfASC {
 //!             // The only important bit about this config is the exact scheme you want to use.
 //!             // SSPRK5 and RKF4 are the go-to choices, though I would recommend the first
 //!             // usually.
 //!             rkf_mode: RKFMode::SSPRK5,
 //!
-//!             // Whether or not to use automatic step control. Not really needed for this test,
-//!             // so we set this to false.
-//!             asc: false,
-//!
 //!             // The relative tolerance when calculating the error between high and low order
 //!             // solutions, used by the automatic step control.
-//!             asc_relative_tolerance: 0.001,
+//!             relative_tolerance: 0.001,
 //!
 //!             // The absolute tolerance when calculating the error between high and low order
 //!             // solutions, used by the automatic step control.
-//!             asc_absolute_tolerance: 0.1,
+//!             absolute_tolerance: 0.1,
 //!
 //!             // The timestep friction factor. This dampens new time steps widths calculated by
 //!             // the automatic step control.
-//!             asc_timestep_friction: 0.08,
-//!         }),
+//!             timestep_friction: 0.08,
+//!         },
 //!
 //!         // How many full loop iterations corries is allowed to run before aborting the
 //!         // simulation, if it has not ended due to other break conditions yet.

--- a/src/time/rkf.rs
+++ b/src/time/rkf.rs
@@ -71,11 +71,22 @@ impl<P: Physics<E, S> + 'static, const E: usize, const S: usize> TimeSolver<P, E
     fn new(config: &CorriesConfig) -> Result<Self> {
         let (bt, asc_relative_tolerance, asc_absolute_tolerance, asc_timestep_friction) =
             match &config.numerics_config.time_integration_config {
-                TimeIntegrationConfig::Rkf(rkf_config) => (
-                    ButcherTableau::new(rkf_config),
-                    rkf_config.asc_relative_tolerance,
-                    rkf_config.asc_absolute_tolerance,
-                    rkf_config.asc_timestep_friction,
+                TimeIntegrationConfig::Rkf { rkf_mode: _ } => (
+                    ButcherTableau::new(&config.numerics_config.time_integration_config),
+                    0.0,
+                    0.0,
+                    0.0,
+                ),
+                TimeIntegrationConfig::RkfASC {
+                    rkf_mode: _,
+                    relative_tolerance,
+                    absolute_tolerance,
+                    timestep_friction,
+                } => (
+                    ButcherTableau::new(&config.numerics_config.time_integration_config),
+                    *relative_tolerance,
+                    *absolute_tolerance,
+                    *timestep_friction,
                 ),
             };
         let order = bt.order;

--- a/src/time/rkf/butchertableau.rs
+++ b/src/time/rkf/butchertableau.rs
@@ -4,7 +4,7 @@
 
 //! Exports the [ButcherTableau] struct
 
-use crate::config::numericsconfig::{RKFMode, RkfConfig};
+use crate::{config::numericsconfig::RKFMode, TimeIntegrationConfig};
 use ndarray::{Array1, Array2};
 
 /// Carries the butcher tableau needed for implement different Runge-Kutta-Fehlberg methods.
@@ -42,11 +42,13 @@ impl ButcherTableau {
     ///
     /// # Argument
     ///
-    /// * `rkfconfig` - [RungeKuttaFehlberg](crate::time::rkf::RungeKuttaFehlberg) specific configuration
-    pub fn new(rkfconfig: &RkfConfig) -> Self {
-        let order = get_order(rkfconfig.rkf_mode);
-        let asc = rkfconfig.asc;
-        match rkfconfig.rkf_mode {
+    /// * `config` - [RungeKuttaFehlberg](crate::time::rkf::RungeKuttaFehlberg) specific configuration
+    pub fn new(config: &TimeIntegrationConfig) -> Self {
+        let (mode, order, asc) = match config {
+            TimeIntegrationConfig::Rkf { rkf_mode } => (*rkf_mode, get_order(*rkf_mode), false),
+            TimeIntegrationConfig::RkfASC { rkf_mode, relative_tolerance: _, absolute_tolerance: _, timestep_friction: _ } => (*rkf_mode, get_order(*rkf_mode), true)
+        };
+        match mode {
             RKFMode::RK1 => Self {
                 order,
                 a: Array2::from_shape_vec(
@@ -66,7 +68,7 @@ impl ButcherTableau {
                     vec![0.0]
                 ).unwrap(),
                 asc: if asc {
-                    println!("WARNING: You turned on automated step control (asc) for {:?}, but this RKF method does not support asc! This option is ignored and asc will be set to false.", rkfconfig.rkf_mode);
+                    println!("WARNING: You turned on automated step control (asc) for {:?}, but this RKF method does not support asc! This option is ignored and asc will be set to false.", mode);
                     false
                 } else {
                     asc
@@ -92,7 +94,7 @@ impl ButcherTableau {
                     vec![0.0, 0.5]
                 ).unwrap(),
                 asc: if asc {
-                    println!("WARNING: You turned on automated step control (asc) for {:?}, but this RKF method does not support asc! This option is ignored and asc will be set to false.", rkfconfig.rkf_mode);
+                    println!("WARNING: You turned on automated step control (asc) for {:?}, but this RKF method does not support asc! This option is ignored and asc will be set to false.", mode);
                     false
                 } else {
                     asc
@@ -142,7 +144,7 @@ impl ButcherTableau {
                     vec![0.0, 0.5, 0.5, 1.0]
                 ).unwrap(),
                 asc: if asc {
-                    println!("WARNING: You turned on automated step control (asc) for {:?}, but this RKF method does not support asc! This option is ignored and asc will be set to false.", rkfconfig.rkf_mode);
+                    println!("WARNING: You turned on automated step control (asc) for {:?}, but this RKF method does not support asc! This option is ignored and asc will be set to false.", mode);
                     false
                 } else {
                     asc


### PR DESCRIPTION
`TimeIntegrationConfig` does not have an embedded struct type (`RkfConfig`) anymore, but rather have proper struct variants.

There are also now separate variants for using RKF with automated step control and without.